### PR TITLE
chore: Switch docker image to Ubuntu and fixed version SILE 0.15.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,25 +46,38 @@ This section is for those who want to generate the PDFs themselves, or contribut
 See further down for a Docker image, if you prefer to be quickly bootstrapped without installing anything on your host system.
 
 Otherwise, you need to have the following tools installed.
-You are on your own checking that you have the right versions of the dependencies and a proper working installation:
+You are on your own checking that you have the right versions of the dependencies and a proper working installation.
 
-- [SILE](https://github.com/sile-typesetter/sile) 0.15.**12**
+ - [**SILE**](https://github.com/sile-typesetter/sile) 0.15.**12** or 0.15.**13**.
 
-  See installation instructions on the SILE website.
+   See installation instructions on the SILE website.
 
-- [LuaRocks](https://luarocks.org/)
+ - Several tools which might be already installed on your system, or which you can install using your regular package manager:
 
-  See installation instructions on the LuaRocks website.
+   - **lilypond** for music notation
+   - **graphviz** for DOT graph rendering
+   - **ghostscript** for PDF image conversion
+   - **inkscape** for SVG image conversion
+   - **graphicsmagick** for image conversion
 
-- The _re·sil·ient_ collection of classes & packages for SILE, a.k.a. [resilient.sile](https://github.com/Omikhleia/resilient.sile).
+ - [**LuaRocks**](https://luarocks.org/)
 
-  ```bash
-  luarocks install resilient.sile
-  ```
+   See installation instructions on the LuaRocks website.
 
-  Be sure to upgrade to the latest version (_minimaly_ to **3.0.0**).
+   Some LuaRocks packages and lower-level dependencies need a C compiler to be installed on your system.
+   Depending on how SILE was built for your system, this might be an additional requirement.
 
-- Decent choice of fonts: Libertinus, EB Garamond, Zallman Caps, Lato.
+ - The _re·sil·ient_ collection of classes & packages for SILE, a.k.a. [resilient.sile](https://github.com/Omikhleia/resilient.sile).
+
+   ```bash
+   luarocks install resilient.sile
+   ```
+
+   Be sure to upgrade to the latest version (_minimaly_ to **3.0.0**).
+
+ - Several fonts: Libertinus, EB Garamond, Zallman Caps, Lato, Hack, Symbola.
+
+   That’s quite a lot, but these are very good fonts, freely available, so you should not have any problem finding them.
 
 ### Generate nice PDF of the books
 
@@ -91,7 +104,7 @@ docker build --progress plain . -f build/Dockerfile -t silex
 Then create an alias, say `resilient`, to run the image:
 
 ```bash
-alias resilient='docker run -it --volume "$(pwd):/data" --user "$(id -u):$(id -g)" silex'
+alias resilient='docker run -it --rm --volume "$(pwd):/data" --user "$(id -u):$(id -g)" silex'
 ```
 
 And use it instead of `sile`:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,40 +1,79 @@
-FROM docker.io/library/archlinux:base
+FROM ubuntu:24.10
 
-# Cleanup of pacman database and cache so layer size stays small at each step
-RUN pacman --noconfirm -Syuq && yes | pacman -Sccq
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Install the necessary components and clean up the cache
-RUN pacman --needed --noconfirm -S \
-    # make (used by the Makefile-fonts)
-    make \
-    # LuaRocks
-    luarocks \
-    git \
-    # SILE
-    sile \
-    # Additional tools used by some of the resilient modules
+# Install dependencies:
+# - ca-certificates: to ensure secure connections
+# - apt-transport-https: to allow APT to use HTTPS
+# - curl: for fetching font files in the Makefile-fonts
+# - build-essential: for 'make' and 'gcc' later if needed by luarocks
+# - libarchive-tools: for 'bsdtar' compatibility (used in the Makefile-fonts)
+# - software-properties-common: to manage PPAs (and have add-apt-repository)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    apt-transport-https \
+    curl \
+    build-essential \
+    libarchive-tools \
+    software-properties-common
+
+# Add curated set of decent fonts for examples
+COPY ./build/Makefile-fonts /
+RUN make -f Makefile-fonts allfonts
+
+# Add the SILE PPA repository
+# software-properties-common is needed to manage PPAs (and have add-apt-repository)
+RUN add-apt-repository ppa:sile-typesetter/sile && apt-get update && apt-cache policy sile
+
+# Install SILE (pinning the version to 0.15.13)
+# and all other dependencies needed by the resilient collection
+RUN apt-get install -y --no-install-recommends \
+    sile=0.15.13-1ppa1~ubuntu24.10 \
     graphicsmagick \
     ghostscript \
     graphviz \
     inkscape \
     lilypond \
-    && yes | pacman -Sccq
+    luajit \
+    git \
+    luarocks \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Curated set of decent fonts for examples
-COPY ./build/Makefile-fonts /
-RUN make -f Makefile-fonts allfonts
-
-# Just to check the version on first run
+# Just to check that SILE runs
+# For reference I got: SILE v0.15.13 (LuaJIT 2.1.1719379426) [Rust]
+RUN echo "SILE version"
 RUN sile --version
 
-# Check the Lua version used by SILE
-# And set it as the default for LuaRocks
+# Check the Lua version used by SILE and set it as the default for LuaRocks
+# We expect it to be 5.1 here as SILE above reported using LuaJIT 2.1), but
+# let's be safe.
 RUN sile -q -e 'print(SILE.lua_version); os.exit()' > /tmp/LVER
 RUN luarocks config lua_version $(cat /tmp/LVER)
 
+# We would expet here to see all Lua dependencies used by SILE
+# With an Arch Linux base image, it worked.
+# I don't know how SILE for Ubuntu is built, but the list is empty here.
+# The consequence is that resilient.sile's own dependencies will install
+# their own versions of Penlight, lpeg, luafilesystem, etc.
+# The latter (at least) requires compilation, so we still need build-essential...
+# RUN luarocks list
+
 # Resilient packages and classes for SILE
+# Yay, at last!
 RUN luarocks install resilient.sile
-RUN luarocks list
+# RUN luarocks list
+
+# Remove some no longer needed packages
+# This wont make the image smaller (due to the way Docker layers work),
+# but it will make the image a bit cleaner
+RUN apt-get purge -y --auto-remove \
+    curl \
+    gnupg \
+    software-properties-common \
+    build-essential \
+    libarchive-tools \
+ && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /data
 ENTRYPOINT ["sile"]

--- a/build/Dockerfile-arch-depreacate
+++ b/build/Dockerfile-arch-depreacate
@@ -1,0 +1,40 @@
+FROM docker.io/library/archlinux:base
+
+# Cleanup of pacman database and cache so layer size stays small at each step
+RUN pacman --noconfirm -Syuq && yes | pacman -Sccq
+
+# Install the necessary components and clean up the cache
+RUN pacman --needed --noconfirm -S \
+    # make (used by the Makefile-fonts)
+    make \
+    # LuaRocks
+    luarocks \
+    git \
+    # SILE
+    sile \
+    # Additional tools used by some of the resilient modules
+    graphicsmagick \
+    ghostscript \
+    graphviz \
+    inkscape \
+    lilypond \
+    && yes | pacman -Sccq
+
+# Curated set of decent fonts for examples
+COPY ./build/Makefile-fonts /
+RUN make -f Makefile-fonts allfonts
+
+# Just to check the version on first run
+RUN sile --version
+
+# Check the Lua version used by SILE
+# And set it as the default for LuaRocks
+RUN sile -q -e 'print(SILE.lua_version); os.exit()' > /tmp/LVER
+RUN luarocks config lua_version $(cat /tmp/LVER)
+
+# Resilient packages and classes for SILE
+RUN luarocks install resilient.sile
+RUN luarocks list
+
+WORKDIR /data
+ENTRYPOINT ["sile"]

--- a/sile-math/bibliography/math-typesetting.bib
+++ b/sile-math/bibliography/math-typesetting.bib
@@ -71,7 +71,7 @@
   title        = {The design and implementation of the Lout document formatting language},
   author       = {Kingston, Jeffrey H.},
   journal      = {Software – Practice and Experience},
-  volume       = {23}, 
+  volume       = {23},
   date         = {1993-09},
   pages        = {1001-1041},
   publisher    = {Queen’s University},
@@ -123,7 +123,7 @@
   date         = {2024-11-19},
   organization = {W3C},
   url          = {https://www.w3.org/TR/2024/WD-mathml4-20241119/},
-}    
+}
 
 @online{mathmlcore,
   title        = {MathML Core Working Draft},


### PR DESCRIPTION
The goal is replace docker build file in order to freeze versions and have reproducible builds
 - Use Ubuntu 24.10 base instead of a rolling Arch Linux
 - Pin version of SILE to 0.15.13

For reference I got: `SILE v0.15.13 (LuaJIT 2.1.1719379426) [Rust]` and tested it was ok.

If I had more time, I'd work on making the image smaller (via more clever layering etc.) and possibly move the fonts to a volume or whatever. I don't have more time, and we have been living here anyway for a long period already with unsatisfying images.

That said, it works, does what it's supposed to do - and should leave me with a minimum of free time without having to worry about updates, which will allow me to work more serenely on the "Tempest project", and its alternative typographic engine(s).
