### PR TITLE
feat(bibliographies): Mythlore indexation

### DIFF
--- a/bibliographies/tolkien/en/jtr.bib
+++ b/bibliographies/tolkien/en/jtr.bib
@@ -688,7 +688,7 @@
   url          = {https://scholar.valpo.edu/journaloftolkienresearch/vol6/iss1/8},
   volume       = {6},
   number       = {1},
-  related      = {una:ferrandezbru2018},
+  related      = {luna:ferrandezbru2018},
   relatedtype  = {reviewof},
 }
 

--- a/bibliographies/tolkien/en/mallorn.bib
+++ b/bibliographies/tolkien/en/mallorn.bib
@@ -5313,7 +5313,7 @@
   url          = {https://journals.tolkiensociety.org/mallorn/article/view/373},
   number       = {4},
   journal      = {Mallorn: The Journal of the Tolkien Society},
-  author       = {Thomson, Steven},
+  author       = {Thomson, Steve},
   year         = {1971},
   month        = {sep},
   pages        = {2},

--- a/bibliographies/tolkien/en/mallorn.bib
+++ b/bibliographies/tolkien/en/mallorn.bib
@@ -2409,6 +2409,7 @@
 -- Issue 33
 
 -- See also Mythlore = Volume 21, Number 2 Issue 80, Winter (1996)
+-- (= https://www.jstor.org/stable/i40240361 which might have some of the articles in open access)
 
 @article{mallorn:chapman1995,
   title        = {Reminiscences: Oxford in 1920, Meeting Tolkien and Becoming an Author at 77},
@@ -2416,16 +2417,16 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Chapman, Vera},
   year         = {1995},
-  pages        = {12},
+  pages        = {12-14},
 }
 
 @article{mallorn:goodknight1995,
   title        = {Tolkien Centenary Banquet Address},
   number       = {33},
   journal      = {Mallorn: The Journal of the Tolkien Society},
-  author       = {GoodKnight, Glen H.},
+  author       = {GoodKnight, Glen},
   year         = {1995},
-  pages        = {15},
+  pages        = {15-16},
 }
 
 @article{mallorn:sayer1995,
@@ -2434,7 +2435,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Sayer, George},
   year         = {1995},
-  pages        = {21},
+  pages        = {21-25},
 }
 
 @article{mallorn:unwin1995,
@@ -2443,7 +2444,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Unwin, Rayner},
   year         = {1995},
-  pages        = {26},
+  pages        = {26-29},
 }
 
 @article{mallorn:agoy1995,
@@ -2452,7 +2453,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Agøy, Nils Ivar},
   year         = {1995},
-  pages        = {31},
+  pages        = {31-38},
 }
 
 @article{mallorn:flieger1995,
@@ -2461,7 +2462,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Flieger, Verlyn},
   year         = {1995},
-  pages        = {39},
+  pages        = {39-44},
 }
 
 @article{mallorn:greene1995a,
@@ -2470,7 +2471,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Greene, Deirdre},
   year         = {1995},
-  pages        = {45},
+  pages        = {45-52},
 }
 
 @article{mallorn:luling1995,
@@ -2479,7 +2480,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Luling, Virginia},
   year         = {1995},
-  pages        = {53},
+  pages        = {53-57},
 }
 
 @article{mallorn:noad1995,
@@ -2488,7 +2489,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Noad, Charles E.},
   year         = {1995},
-  pages        = {58},
+  pages        = {58-62},
 }
 
 @article{mallorn:stclair1995a,
@@ -2497,7 +2498,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {St. Clair, Gloriana},
   year         = {1995},
-  pages        = {63},
+  pages        = {63-67},
 }
 
 @article{mallorn:stclair1995b,
@@ -2506,7 +2507,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {St. Clair, Gloriana},
   year         = {1995},
-  pages        = {68},
+  pages        = {68-72},
 }
 
 @article{mallorn:seeman1995,
@@ -2515,7 +2516,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Seeman, Chris},
   year         = {1995},
-  pages        = {73},
+  pages        = {73-83},
 }
 
 @article{mallorn:shippey1995a,
@@ -2524,7 +2525,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Shippey, T. A.},
   year         = {1995},
-  pages        = {84},
+  pages        = {84-93},
 }
 
 @article{mallorn:talbot1995,
@@ -2533,7 +2534,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Talbot, Norman},
   year         = {1995},
-  pages        = {94},
+  pages        = {94-106},
 }
 
 @article{mallorn:bums1995,
@@ -2542,7 +2543,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Bums, Marjorie},
   year         = {1995},
-  pages        = {108},
+  pages        = {108-114},
 }
 
 @article{mallorn:chance1995,
@@ -2551,7 +2552,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Chance, Jane},
   year         = {1995},
-  pages        = {115},
+  pages        = {115-120},
 }
 
 @article{mallorn:christopher1995a,
@@ -2560,7 +2561,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Christopher, Joe R.},
   year         = {1995},
-  pages        = {121},
+  pages        = {121-125},
 }
 
 @article{mallorn:curry1995,
@@ -2569,7 +2570,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Curry, Patrick},
   year         = {1995},
-  pages        = {126},
+  pages        = {126-138},
 }
 
 @article{mallorn:hood1995,
@@ -2578,7 +2579,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Hood, Gwenyth},
   year         = {1995},
-  pages        = {139},
+  pages        = {139-144},
 }
 
 @article{mallorn:stclair1995c,
@@ -2587,7 +2588,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {St. Clair, Gloriana},
   year         = {1995},
-  pages        = {145},
+  pages        = {145-150},
 }
 
 @article{mallorn:scull1995,
@@ -2596,7 +2597,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Scull, Christina},
   year         = {1995},
-  pages        = {151},
+  pages        = {151-156},
 }
 
 @article{mallorn:lewis1995,
@@ -2605,7 +2606,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Lewis, Alex},
   year         = {1995},
-  pages        = {158},
+  pages        = {158-166},
 }
 
 @article{mallorn:schweicher1995,
@@ -2614,7 +2615,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Schweicher, Eric},
   year         = {1995},
-  pages        = {167},
+  pages        = {167-171},
 }
 
 @article{mallorn:gilliver1995,
@@ -2623,7 +2624,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Gilliver, Peter},
   year         = {1995},
-  pages        = {173},
+  pages        = {173-186},
 }
 
 @article{mallorn:gilson1995,
@@ -2632,7 +2633,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Gilson, Christopher and Wynne, Patrick},
   year         = {1995},
-  pages        = {187},
+  pages        = {187-194},
 }
 
 @article{mallorn:greene1995b,
@@ -2641,7 +2642,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Greene, Deirdre},
   year         = {1995},
-  pages        = {195},
+  pages        = {195-199},
 }
 
 @article{mallorn:grigorjeva1995,
@@ -2650,7 +2651,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Grigorjeva, Natalia},
   year         = {1995},
-  pages        = {200},
+  pages        = {200-205},
 }
 
 @article{mallorn:mitchell1995,
@@ -2659,16 +2660,16 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Mitchell, Bruce},
   year         = {1995},
-  pages        = {206},
+  pages        = {206-212},
 }
 
 @article{mallorn:shippey1995b,
-  title        = {Tolkien and the Gawain-poet},
+  title        = {Tolkien and the _Gawain_-poet},
   number       = {33},
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Shippey, T. A.},
   year         = {1995},
-  pages        = {213},
+  pages        = {213-219},
 }
 
 @article{mallorn:grushetskiy1995,
@@ -2677,7 +2678,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Grushetskiy, Vladimir},
   year         = {1995},
-  pages        = {221},
+  pages        = {221-225},
 }
 
 @article{mallorn:hammond1995,
@@ -2686,7 +2687,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Hammond, Wayne G.},
   year         = {1995},
-  pages        = {226},
+  pages        = {226-232},
 }
 
 @article{mallorn:yates1995,
@@ -2695,7 +2696,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Yates, Jessica},
   year         = {1995},
-  pages        = {233},
+  pages        = {233-245},
 }
 
 @article{mallorn:armstrong1995,
@@ -2704,16 +2705,16 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Armstrong, Helen},
   year         = {1995},
-  pages        = {247},
+  pages        = {247-252},
 }
 
 @article{mallorn:barkley1995,
-  title        = {The Realm of Faerie},
+  title        = {The Realm of Faërie},
   number       = {33},
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Barkley, Christine},
   year         = {1995},
-  pages        = {253},
+  pages        = {253-255},
 }
 
 @article{mallorn:christopher1995b,
@@ -2722,7 +2723,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Christopher, Joe R.},
   year         = {1995},
-  pages        = {256},
+  pages        = {256-262},
 }
 
 @article{mallorn:christopher1995c,
@@ -2731,7 +2732,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Christopher, Joe R.},
   year         = {1995},
-  pages        = {263},
+  pages        = {263-271},
 }
 
 @article{mallorn:crowe1995,
@@ -2740,7 +2741,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Crowe, Edith L.},
   year         = {1995},
-  pages        = {272},
+  pages        = {272-277},
 }
 
 @article{mallorn:hopkins1995a,
@@ -2749,7 +2750,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Hopkins, Chris},
   year         = {1995},
-  pages        = {278},
+  pages        = {278-280},
 }
 
 @article{mallorn:hostetter1995,
@@ -2758,7 +2759,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Hostetter, Carl F. and Smith, Arden R.},
   year         = {1995},
-  pages        = {281},
+  pages        = {281-290},
 }
 
 @article{mallorn:martsch1995,
@@ -2767,7 +2768,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Martsch, Nancy},
   year         = {1995},
-  pages        = {291},
+  pages        = {291-297},
 }
 
 @article{mallorn:olszanski1995,
@@ -2776,7 +2777,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Olszanski, Tadeusz Andrzej},
   year         = {1995},
-  pages        = {298},
+  pages        = {298-300},
 }
 
 @article{mallorn:rossenberg1995,
@@ -2785,7 +2786,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Rossenberg, René van},
   year         = {1995},
-  pages        = {301},
+  pages        = {301-309},
 }
 
 @article{mallorn:stentstrom2004,
@@ -2794,7 +2795,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Stentström, Anders},
   year         = {1995},
-  pages        = {310},
+  pages        = {310-314},
 }
 
 @article{mallorn:thorpe1995,
@@ -2803,7 +2804,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Thorpe, Dwayne},
   year         = {1995},
-  pages        = {315},
+  pages        = {315-321},
 }
 
 @article{mallorn:coombs1995,
@@ -2812,7 +2813,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Coombs, Jenny and Read, Marc},
   year         = {1995},
-  pages        = {323},
+  pages        = {323-329},
 }
 
 @article{mallorn:funk1995,
@@ -2821,7 +2822,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Funk, David A.},
   year         = {1995},
-  pages        = {330},
+  pages        = {330-333},
 }
 
 @article{mallorn:sarjeant1995,
@@ -2830,7 +2831,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Sarjeant, William A. S.},
   year         = {1995},
-  pages        = {334},
+  pages        = {334-339},
 }
 
 @article{mallorn:simons1995,
@@ -2839,7 +2840,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Simons, Lester E.},
   year         = {1995},
-  pages        = {340},
+  pages        = {340-343},
 }
 
 @article{mallorn:coulombe1995,
@@ -2848,7 +2849,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Coulombe, Charles A.},
   year         = {1995},
-  pages        = {345},
+  pages        = {345-355},
 }
 
 @article{mallorn:doughan1995a,
@@ -2857,7 +2858,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Doughan, David},
   year         = {1995},
-  pages        = {356},
+  pages        = {356-359},
 }
 
 @article{mallorn:duriez1995,
@@ -2866,7 +2867,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Duriez, Colin},
   year         = {1995},
-  pages        = {360},
+  pages        = {360-363},
 }
 
 @article{mallorn:hopkins1995b,
@@ -2875,7 +2876,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Hopkins, Lisa},
   year         = {1995},
-  pages        = {364},
+  pages        = {364-366},
 }
 
 @article{mallorn:pavlac1995,
@@ -2884,7 +2885,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Pavlac, Diana Lynne},
   year         = {1995},
-  pages        = {367},
+  pages        = {367-374},
 }
 
 @article{mallorn:yandell1995,
@@ -2893,7 +2894,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Yandell, Stephen},
   year         = {1995},
-  pages        = {375},
+  pages        = {375-392},
 }
 
 @article{mallorn:ellison1995,
@@ -2902,7 +2903,7 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Ellison, John},
   year         = {1995},
-  pages        = {394},
+  pages        = {394-395},
 }
 
 @article{mallorn:sawa1995,
@@ -2911,8 +2912,10 @@
   journal      = {Mallorn: The Journal of the Tolkien Society},
   author       = {Sawa, Hubert},
   year         = {1995},
-  pages        = {396},
+  pages        = {396-410},
 }
+
+% Other articles in this issue are not included here as they are not related to Tolkien.
 
 -- Issue 32
 

--- a/bibliographies/tolkien/en/mythlore.bib
+++ b/bibliographies/tolkien/en/mythlore.bib
@@ -624,6 +624,8 @@ https://www.jstor.org/stable/26807246
   number        = {1 (13)},
   year          = {1976},
   pages         = {21-22},
+  related       = {kilby1976},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 4, No. 2 (14), December 1976
@@ -724,6 +726,8 @@ https://www.jstor.org/stable/26807246
   number        = {1 (17)},
   year          = {1978},
   pages         = {29-30},
+  related       = {ts:allan1975},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:nelson1978,
@@ -1258,10 +1262,11 @@ https://www.jstor.org/stable/26807246
   pages         = {31},
 }
 
+% Review author not clearly specified in print, but confirmed by the Mythlore Index Plus Reviews.
 @article{mythlore:crabbe1982,
   title         = {Language and Creativity: _J.~R.~R. Tolkien_ by Katharyn F. Crabbe (review)},
   url           = {https://www.jstor.org/stable/26809957},
-  author        = {Crabbe, Katharyn F.},
+  author        = {Patterson, Nancy-Lou},
   journal       = {Mythlore},
   volume        = {9},
   number        = {2 (32)},
@@ -1642,6 +1647,7 @@ https://www.jstor.org/stable/26807246
   pages         = {30-32},
 }
 
+% Here kent:flieger2002 is a newer edition of the reviewed book, but we aren't going to include all editions in the bibliography.
 @article{mythlore:patterson1984,
   title         = {All About Light: _Splintered Light: Logos and Language in Tolkien’s World_ by Verlyn Flieger (review)},
   url           = {https://www.jstor.org/stable/26810547},
@@ -1651,6 +1657,8 @@ https://www.jstor.org/stable/26807246
   number        = {1 (39)},
   year          = {1984},
   pages         = {32-33},
+  related       = {kent:flieger2002},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:egan1984b,
@@ -4191,6 +4199,8 @@ T@article{mythlore:bratman2000,
   number        = {1/2 (99/100)},
   year          = {2007},
   pages         = {209-212},
+  related       = {cormare11},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 26, No. 3/4 (101/102), Spring/Summer 2008
@@ -4260,6 +4270,8 @@ T@article{mythlore:bratman2000,
   number        = {3/4 (101/102)},
   year          = {2008},
   pages         = {199-201},
+  related       = {mcfarland:croft2007},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:bratman2008,
@@ -4271,6 +4283,8 @@ T@article{mythlore:bratman2000,
   number        = {3/4 (101/102)},
   year          = {2008},
   pages         = {201-203},
+  related       = {mcfarland:whittingham2008},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:fisher2008a,
@@ -4340,6 +4354,8 @@ T@article{mythlore:bratman2000,
   number        = {1/2 (103/104)},
   year          = {2008},
   pages         = {175-181},
+  related       = {cormare14},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:crowe2008,
@@ -4351,6 +4367,8 @@ T@article{mythlore:bratman2000,
   number        = {1/2 (103/104)},
   year          = {2008},
   pages         = {186-188},
+  related       = {cambridge:mirrorcrackd},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:fisher2008c,
@@ -4602,6 +4620,8 @@ T@article{mythlore:bratman2000,
   number        = {1/2 (111/112)},
   year          = {2010},
   pages         = {183-186},
+  related       = {mcfarland:minstrel},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 29, No. 3/4 (113/114), Spring/Summer 2011
@@ -4693,6 +4713,8 @@ T@article{mythlore:bratman2000,
   number        = {3/4 (113/114)},
   year          = {2011},
   pages         = {192-195},
+  related       = {cormare18},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:bratman2011,
@@ -4751,6 +4773,8 @@ T@article{mythlore:bratman2000,
   number        = {1/2 (115/116)},
   year          = {2011},
   pages         = {176-181},
+  related       = {fdu:ringandcross},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:foster2011,
@@ -4762,6 +4786,8 @@ T@article{mythlore:bratman2000,
   number        = {1/2 (115/116)},
   year          = {2011},
   pages         = {189-192},
+  related       = {mcfarland:sources},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 30, No. 3/4 (117/118), Spring/Summer 2012
@@ -4809,6 +4835,8 @@ T@article{mythlore:bratman2000,
   number        = {3/4 (117/118)},
   year          = {2012},
   pages         = {151-152},
+  related       = {mcfarland:picturing},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:sims2012a,
@@ -4831,6 +4859,8 @@ T@article{mythlore:bratman2000,
   number        = {3/4 (117/118)},
   year          = {2012},
   pages         = {173-182},
+  related       = {uwp:phelpstead2011},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 31, No. 1/2 (119/120), Fall/Winter 2012
@@ -4856,6 +4886,8 @@ T@article{mythlore:bratman2000,
   number        = {1/2 (119/120)},
   year          = {2012},
   pages         = {173-177},
+  related       = {cormare4},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:brown2012b,
@@ -4867,6 +4899,8 @@ T@article{mythlore:bratman2000,
   number        = {1/2 (119/120)},
   year          = {2012},
   pages         = {177-184},
+  related       = {cormare6},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:ordway2012,
@@ -4958,6 +4992,8 @@ T@article{mythlore:bratman2000,
   number        = {3/4 (121/122)},
   year          = {2013},
   pages         = {127-129},
+  related       = {cormare23},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:sims2013,
@@ -4969,6 +5005,8 @@ T@article{mythlore:bratman2000,
   number        = {3/4 (121/122)},
   year          = {2013},
   pages         = {129-136},
+  related       = {cormare26},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 32, No. 1 (123), Fall/Winter 2013
@@ -5060,6 +5098,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (123)},
   year          = {2013},
   pages         = {162-167},
+  related       = {cormare28},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 32, No. 2 (124), Spring/Summer 2014
@@ -5118,6 +5158,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (124)},
   year          = {2014},
   pages         = {177-180},
+  related       = {palgravemacmillan:roberts2013},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:green2014,
@@ -5140,6 +5182,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (124)},
   year          = {2014},
   pages         = {192-194},
+  related       = {oxford:gilliver2009},
+  relatedtype   = {reviewof},
 }
 
 
@@ -5152,6 +5196,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (124)},
   year          = {2014},
   pages         = {194-198},
+  related       = {fourcourts:tolkienforestcity},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 33, No. 1 (125), Fall/Winter 2014
@@ -5199,6 +5245,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (125)},
   year          = {2014},
   pages         = {146-149},
+  related       = {mcfarland:body},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:higgins2014,
@@ -5210,6 +5258,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (125)},
   year          = {2014},
   pages         = {153-163},
+  related       = {cormare30},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 33, No. 2 (126), Spring/Summer 2015
@@ -5290,6 +5340,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (126)},
   year          = {2015},
   pages         = {171-175},
+  related       = {mcfarland:nicolay2014},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:foster2015,
@@ -5381,6 +5433,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (127)},
   year          = {2015},
   pages         = {163-165},
+  related       = {higgens2014},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:larson2015,
@@ -5392,6 +5446,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (127)},
   year          = {2015},
   pages         = {171-176},
+  related       = {kent:jeffers2014},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 34, No. 2 (128), Spring/Summer 2016
@@ -5450,6 +5506,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (128)},
   year          = {2016},
   pages         = {181-184},
+  related       = {undpress:tolkienmoderns},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:coker2016,
@@ -5541,6 +5599,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (129)},
   year          = {2016},
   pages         = {188-190},
+  related       = {donovan2015},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:fisher2016,
@@ -5552,6 +5612,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (129)},
   year          = {2016},
   pages         = {191-200},
+  related       = {wileyblackwell:companion2014},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 35, No. 2 (130), Spring/Summer 2017
@@ -5713,6 +5775,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (131)},
   year          = {2017},
   pages         = {213-219},
+  related       = {palgravemacmillan:coutras2016},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:croft2017b,
@@ -5724,6 +5788,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (131)},
   year          = {2017},
   pages         = {221-224},
+  related       = {cormare35},
+  relatedtype   = {reviewof},  
 }
 
 @article{mythlore:emerson2017,
@@ -5771,6 +5837,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (132)},
   year          = {2018},
   pages         = {113-121},
+  related       = {comare36},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:tredray2018,
@@ -5964,6 +6032,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (134)},
   year          = {2019},
   pages         = {170-186},
+  related       = {apocryphile:arthur},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:fisher2019,
@@ -5975,6 +6045,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (134)},
   year          = {2019},
   pages         = {187-199},
+  related       = {palgravemacmillan:chance2016,palgravemacmillan:alterity},
+  relatedtype   = {reviewof,reviewof},
 }
 
 @article{mythlore:smith2019,
@@ -5986,6 +6058,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (134)},
   year          = {2019},
   pages         = {208-211},
+  related       = {kent:amendtraduege2017},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:steele2019,
@@ -5997,6 +6071,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (134)},
   year          = {2019},
   pages         = {222-226},
+  related       = {kent:rhone2017},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 38, No. 1 (135), Fall/Winter 2019, Special Issue: Mythopoeic Children’s Literature
@@ -6102,6 +6178,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (136)},
   year          = {2020},
   pages         = {189-191},
+  related       = {cormare42},
+  relatedtype   = {reviewof},  
 }
 
 @article{mythlore:freeman2020,
@@ -6124,6 +6202,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (136)},
   year          = {2020},
   pages         = {195-204},
+  related       = {luna:cilli2019},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:emerson2020,
@@ -6135,6 +6215,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (136)},
   year          = {2020},
   pages         = {216-217},
+  related       = {cormare32},
+  relatedtype   = {reviewof},  
 }
 
 @article{mythlore:prothero2020,
@@ -6146,6 +6228,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (136)},
   year          = {2020},
   pages         = {219-221},
+  related       = {cormare41},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 39, No. 1 (137), Fall/Winter 2020
@@ -6204,6 +6288,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (137)},
   year          = {2020},
   pages         = {195-198},
+  related       = {bloomsbury:doyle2019},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:fontenot2020,
@@ -6215,6 +6301,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (137)},
   year          = {2020},
   pages         = {198-206},
+  related       = {cormare39},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:schmoll2020,
@@ -6237,6 +6325,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (137)},
   year          = {2020},
   pages         = {220-229},
+  related       = {garth2020},
+  relatedtype   = {reviewof},
 }
 
 
@@ -6252,6 +6342,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (138)},
   year          = {2021},
   pages         = {159-162},
+  related       = {oxford:bowers2019},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:glyer2021,
@@ -6274,6 +6366,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (138)},
   year          = {2021},
   pages         = {199-207},
+  related       = {palgravemacmillan:vaninskaya2020},
+  relatedtype   = {reviewof}
 }
 
 -- Mythlore. Vol. 40, No. 1 (139), Fall/Winter 2021
@@ -6354,6 +6448,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (139)},
   year          = {2021},
   pages         = {249-256},
+  related       = {wofa:ordway2021},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:white2021,
@@ -6365,6 +6461,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (139)},
   year          = {2021},
   pages         = {264-268},
+  related       = {ts:2019},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 40, No. 2 (140), Spring/Summer 2022
@@ -6445,6 +6543,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (140)},
   year          = {2022},
   pages         = {262-266},
+  related       = {ts:1999},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:thibodeaux2022,
@@ -6456,6 +6556,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (140)},
   year          = {2022},
   pages         = {266-269},
+  related       = {cormare38},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:costabile2022,
@@ -6467,6 +6569,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (140)},
   year          = {2022},
   pages         = {270-272},
+  related       = {cormare44},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:tally2022a,
@@ -6478,6 +6582,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (140)},
   year          = {2022},
   pages         = {272-275},
+  related       = {kent:grybauskas2021},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:swain2022,
@@ -6489,6 +6595,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (140)},
   year          = {2022},
   pages         = {276-281},
+  related       = {cormare45},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:houghton2022,
@@ -6500,6 +6608,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (140)},
   year          = {2022},
   pages         = {281-284},
+  related       = {pickwick:bertoglio2021},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:white2022,
@@ -6569,10 +6679,12 @@ T@article{mythlore:bratman2000,
   number        = {1 (141)},
   year          = {2022},
   pages         = {253-258},
+  related      = {palgravemacmillan:stuart2022},
+  relatedtype  = {reviewof},
 }
 
 @article{mythlore:brians2022,
-  title         = {Friendship In _The Lord of the Rings_ by Cristina Casagrande, Eduardo Boheme (review)},
+  title         = {_Friendship In The Lord of the Rings_ by Cristina Casagrande, Eduardo Boheme (review)},
   url           = {https://www.jstor.org/stable/48692607},
   author        = {Brians, Mark A.},
   journal       = {Mythlore},
@@ -6591,6 +6703,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (141)},
   year          = {2022},
   pages         = {277-284},
+  related      = {palgravemacmillan:kullmannsiepmann2021},
+  relatedtype  = {reviewof},
 }
 
 -- Mythlore. Vol. 41, No. 2 (142), Spring/Summer 2023
@@ -6693,6 +6807,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (142)},
   year          = {2023},
   pages         = {247-251},
+  related       = {kent:lehning2022},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:portaencasa2023,
@@ -6704,6 +6820,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (142)},
   year          = {2023},
   pages         = {264-266},
+  related       = {cormare46},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:lenz2023,
@@ -6715,6 +6833,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (142)},
   year          = {2023},
   pages         = {274-280},
+  related       = {kent:rosegrant2021},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 42, No. 1 (143), Fall/Winter 2023
@@ -6828,6 +6948,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (143)},
   year          = {2023},
   pages         = {217-225},
+  related       = {luna:ferrandezbru2018},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:ostaltsev2023,
@@ -6839,6 +6961,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (143)},
   year          = {2023},
   pages         = {230-234},
+  related       = {lexham:freeman2022},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:martsch2023b,
@@ -6850,6 +6974,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (143)},
   year          = {2023},
   pages         = {237-242},
+  related       = {mcfarland:bacelli2022},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:white2023,
@@ -6861,6 +6987,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (143)},
   year          = {2023},
   pages         = {246-248},
+  related       = {ts:2021},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:martsch2023c,
@@ -6872,6 +7000,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (143)},
   year          = {2023},
   pages         = {253-257},
+  related       = {cormare47},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:coker2023,
@@ -6883,6 +7013,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (143)},
   year          = {2023},
   pages         = {260-262},
+  related       = {bodleian:greattales},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 42, No. 2 (144), Spring/Summer 2024, Special Issue: Fantasy Goes to Hell
@@ -6933,7 +7065,7 @@ T@article{mythlore:bratman2000,
 }
 
 @article{mythlore:martsch2024,
-  title         = {_J.~R.~R. Tolkien in Central Europe: Context, Directions, and the Legacy._ by Janka Kascakova, David Levente Palatinus (review)},
+  title         = {_J.~R.~R. Tolkien in Central Europe: Context, Directions, and the Legacy._ by Janka Kaščáková, David Levente Palatinus (review)},
   url           = {https://www.jstor.org/stable/48772010},
   author        = {Martsch, Nancy},
   journal       = {Mythlore},
@@ -6941,6 +7073,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (144)},
   year          = {2024},
   pages         = {227-231},
+  related      = {routledge:centraleurope},
+  relatedtype  = {reviewof},
 }
 
 @article{mythlore:vandyke2024,
@@ -6985,6 +7119,8 @@ T@article{mythlore:bratman2000,
   number        = {2 (144)},
   year          = {2024},
   pages         = {264-265},
+  related       = {costabile2022},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 43, No. 1 (145), Fall/Winter 2024
@@ -7065,6 +7201,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (145)},
   year          = {2024},
   pages         = {265-268},
+  related       = {bloomsbury:williams2023},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:portaencasa2024,
@@ -7076,6 +7214,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (145)},
   year          = {2024},
   pages         = {275-281},
+  related       = {routledge:birns2024},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:costabile2024b,
@@ -7087,6 +7227,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (145)},
   year          = {2024},
   pages         = {288-292},
+  related       = {kent:hillman2023},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:schurer2024,
@@ -7098,6 +7240,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (145)},
   year          = {2024},
   pages         = {296-300},
+  related       = {mcfarland:tally2024},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:griffinordway2024,
@@ -7109,6 +7253,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (145)},
   year          = {2024},
   pages         = {301-306},
+  related       = {wofa:ordway2023},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:coker2024,
@@ -7120,6 +7266,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (145)},
   year          = {2024},
   pages         = {317-321},
+  related       = {bloomsbury:reinders2024},
+  relatedtype   = {reviewof},
 }
 
 @article{mythlore:forchhammer2024,
@@ -7131,6 +7279,8 @@ T@article{mythlore:bratman2000,
   number        = {1 (145)},
   year          = {2024},
   pages         = {321-323},
+  related       = {cormare37},
+  relatedtype   = {reviewof},
 }
 
 -- Mythlore. Vol. 43, No. 2 (146), Spring/Summer 2025

--- a/bibliographies/tolkien/en/mythlore.bib
+++ b/bibliographies/tolkien/en/mythlore.bib
@@ -1,0 +1,7258 @@
+-- Mythlore. Vol. 1, No. 1, January 1969
+-- https://www.jstor.org/stable/i26807204
+
+@article{mythlore:berman1969,
+  title         = {Here an Orc, There an Ork},
+  url           = {https://www.jstor.org/stable/26807208},
+  author        = {Berman, Ruth},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {1},
+  year          = {1969},
+  pages         = {8-11},
+}
+
+@article{mythlore:ballif1969a,
+  title         = {A Sindarin-Quenya Dictionary, More or Less, Listing All Elvish Words Found in _The Lord of the Rings, The Hobbit_ and _The Road Goes Ever On_ by J.~R.~R. Tolkien (Part 1)},
+  url           = {https://www.jstor.org/stable/26807218},
+  author        = {Ballif, Sandra},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {1},
+  year          = {1969},
+  pages         = {41-44},
+}
+
+-- Mythlore. Vol. 1, No. 2, April 1969
+-- https://www.jstor.org/stable/i26807298
+
+% Commented out - on closer inspection, it appears to be some editorial column, not a Tolkien-related article.
+@comment{mythlore:goodknight1969,
+  title         = {The Counsel of Elrond},
+  url           = {https://www.jstor.org/stable/26807300},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {2},
+  year          = {1969},
+  pages         = {4-5, 16},
+}
+
+% Commented out - on closer inspection, about many things, more kind of generic column (?)
+@comment{mythlore:zuber1969,
+  title         = {Across the Brandywine},
+  url           = {https://www.jstor.org/stable/26807303},
+  author        = {Zuber, Bernie},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {2},
+  year          = {1969},
+  pages         = {11-12},
+}
+
+@article{mythlore:barczak1969a,
+  title         = {Ring of Power (a conservationist view)},
+  url           = {https://www.jstor.org/stable/26807304},
+  author        = {Barczak, Christopher},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {2},
+  year          = {1969},
+  pages         = {13},
+}
+
+@article{mythlore:duriez1969,
+  title         = {Leonardo, Tolkien, and Mr. Baggins},
+  url           = {https://www.jstor.org/stable/26807306},
+  author        = {Duriez, Colin},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {2},
+  year          = {1969},
+  pages         = {17, 19-28},
+}
+
+@article{mythlore:ballif1969b,
+  title         = {A Sindarin-Quenya Dictionary, More or Less, Listing All Elvish Words Found in _The Lord of the Rings, The Hobbit_ and _The Road Goes Ever On_ by J.~R.~R. Tolkien (Part 2)},
+  url           = {https://www.jstor.org/stable/26807311},
+  author        = {Ballif, Sandra},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {2},
+  year          = {1969},
+  pages         = {33-36},
+}
+
+-- Mythlore. Vol. 1, No. 3, July 1969
+-- https://www.jstor.org/stable/i26807243
+
+"What has it got in its pocketses?" (pp. 2-3)
+George Barr
+https://www.jstor.org/stable/26807245
+@article{mythlore:barr1969,
+  title         = {"What has it got in its pocketses?"},
+  url           = {https://www.jstor.org/stable/26807245},
+  author        = {Barr, George},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {3},
+  year          = {1969},
+  pages         = {2-3},
+}
+
+The Counsel of Elrond (p. 4)
+Glen GoodKnight
+https://www.jstor.org/stable/26807246
+% Commented out - on closer inspection, it appears to be some editorial column, not a Tolkien-related article.
+@comment{mythlore:goodknight1969,
+  title         = {The Counsel of Elrond},
+  url           = {https://www.jstor.org/stable/26807246},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {3},
+  year          = {1969},
+  pages         = {4},
+}
+
+% Commented out - on closer inspection, about many things, more kind of generic column (?)
+@comment{mythlore:zuber1969,
+  title         = {Across the Brandywine},
+  url           = {https://www.jstor.org/stable/26807247},
+  author        = {Zuber, Bernie},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {3},
+  year          = {1969},
+  pages         = {5-7},
+}
+
+@article{mythlore:braude1969,
+  title         = {Tolkien & Spenser},
+  url           = {https://www.jstor.org/stable/26807248},
+  author        = {Braude, Nan},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {3},
+  year          = {1969},
+  pages         = {8-11, 13},
+}
+
+@article{mythlore:ellwood1969,
+  title         = {The Japanese Hobbit},
+  url           = {https://www.jstor.org/stable/26807249},
+  author        = {Ellwood, Robert},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {3},
+  year          = {1969},
+  pages         = {14-17},
+}
+
+@article{mythlore:goodknight1969,
+  title         = {A Comparison of Cosmological Geography in the works of J.~R.~R. Tolkien, C.~S. Lewis, and Charles Williams},
+  url           = {https://www.jstor.org/stable/26807250},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {3},
+  year          = {1969},
+  pages         = {18-22},
+}
+
+@article{mythlore:callahan1969,
+  title         = {A Lost Page from The Red Book of Westmarch},
+  url           = {https://www.jstor.org/stable/26807252},
+  author        = {Callahan, Patrick},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {3},
+  year          = {1969},
+  pages         = {25, 27},
+}
+
+@article{mythlore:barczak1969b,
+  title         = {The Punishment of Sauron},
+  url           = {https://www.jstor.org/stable/26807253},
+  author        = {Barczak, Christopher},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {3},
+  year          = {1969},
+  pages         = {26-27},
+}
+
+-- Mythlore. Vol. 1, No. 4, October 1969
+-- https://www.jstor.org/stable/i26807318
+
+% Commented out - on closer inspection, it appears to be some editorial column, not a Tolkien-related article.
+@comment{mythlore:goodknight1969,
+  title         = {The Counsel of Elrond},
+  url           = {https://www.jstor.org/stable/26807320},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {4},
+  year          = {1969},
+  pages         = {2-3, 54-55},
+}
+
+% Commented out - on closer inspection, about many things, more kind of generic column (?)
+@comment{mythlore:zuber1969,
+  title         = {Across the Brandywíne},
+  url           = {https://www.jstor.org/stable/26807321},
+  author        = {Zuber, Berníe},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {4},
+  year          = {1969},
+  pages         = {4-5, 7},
+}
+
+% Commented out - pseudonym = not going to include
+@comment{mythlore:peredhil1969,
+  title         = {Bílbo and Frodo’s Bírthday Party},
+  url           = {https://www.jstor.org/stable/26807326},
+  author        = {Peredhil, Elrond},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {4},
+  year          = {1969},
+  pages         = {21, 54},
+}
+
+@article{mythlore:juhren1969,
+  title         = {Mileage in Middle-earth},
+  url           = {https://www.jstor.org/stable/26807327},
+  author        = {Juhren, Marcella},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {4},
+  year          = {1969},
+  pages         = {22},
+}
+
+@article{mythlore:ballif1969c,
+  title         = {A Sindarin-Quenya Dictionary, More or Less, Listing All Elvish Words Found in _The Lord of the Rings, The Hobbit_ and _The Road Goes Ever On_ by J.~R.~R. Tolkien (Part 3)},
+  url           = {https://www.jstor.org/stable/26807328},
+  author        = {Ballif, Sandra},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {4},
+  year          = {1969},
+  pages         = {23-26},
+}
+
+@article{mythlore:kuhl1969,
+  title         = {Arrows From A Twisted Bow: Misunderstanding Tolkien— _Understanding Tolkien and The Lord of the Rings_ by William Ready (review)},
+  url           = {https://www.jstor.org/stable/26807333},
+  author        = {Kuhl, Rand},
+  journal       = {Mythlore},
+  volume        = {1},
+  number        = {4},
+  year          = {1969},
+  pages         = {45-49},
+}
+
+-- Mythlore. Vol. 2, No. 1 (5), Winter 1970
+-- https://www.jstor.org/stable/i26807261
+
+% Commented out - on closer inspection, it appears to be some editorial column, not a Tolkien-related article.
+@comment{mythlore:goodknight1970,
+  title         = {The Counsel of Elrond: Affirming the Images},
+  url           = {https://www.jstor.org/stable/26807282},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {1 (5)},
+  year          = {1970},
+  pages         = {2-3},
+}
+
+% Commented out - on closer inspection, about many things, more kind of generic column (?)
+@comment{mythlore:zuber1970,
+  title         = {Across the Brandywine},
+  url           = {https://www.jstor.org/stable/26807283},
+  author        = {Zuber, Bernie},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {1 (5)},
+  year          = {1970},
+  pages         = {3},
+}
+
+@article{mythlore:juhren1970,
+  title         = {The Ecology of Middle Earth},
+  url           = {https://www.jstor.org/stable/26807284},
+  author        = {Juhren, Marcella},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {1 (5)},
+  year          = {1970},
+  pages         = {4-6},
+}
+
+@article{mythlore:goodknight1970,
+  title         = {The Social History of the Inklings, J.~R.~R. Tolkien, C.~S. Lewis, Charles Williams, 1939—1945},
+  url           = {https://www.jstor.org/stable/26807285},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {1 (5)},
+  year          = {1970},
+  pages         = {7-9},
+}
+
+@article{mythlore:mckenzie1970,
+  title         = {"Above All Shadows Rides the Sun"},
+  url           = {https://www.jstor.org/stable/26807293},
+  author        = {McKenzie, Elizabeth},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {1 (5)},
+  year          = {1970},
+  pages         = {18},
+}
+
+-- Mythlore. Vol. 2, No. 2 (6), Autumn 1970
+-- https://www.jstor.org/stable/i26807223
+
+% Commented out - on closer inspection, it appears to be some editorial column, not a Tolkien-related article.
+@comment{mythlore:goodknight1970,
+  title         = {The Counsel of Elrond: Affirming the Images},
+  url           = {https://www.jstor.org/stable/26807225},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {2 (6)},
+  year          = {1970},
+  pages         = {3-4},
+}
+
+% Commented out - on closer inspection, about many things, more kind of generic column (?)
+@comment{mythlore:zuber1970,
+  title         = {Across the Brandywine},
+  url           = {https://www.jstor.org/stable/26807226},
+  author        = {Zuber, Bernie},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {2 (6)},
+  year          = {1970},
+  pages         = {3-4},
+}
+
+-- Mythlore. Vol. 2, No. 3 (7), Winter 1971
+-- https://www.jstor.org/stable/i26807338
+
+@article{mythlore:marmor1971,
+  title         = {An Etymological Excursion Among the Shire Folk},
+  url           = {https://www.jstor.org/stable/26807342},
+  author        = {Marmor, Paula},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {3 (7)},
+  year          = {1971},
+  pages         = {4},
+}
+
+@article{mythlore:masson1971,
+  title         = {Tom Bombadil: A Critical Essay},
+  url           = {https://www.jstor.org/stable/26807344},
+  author        = {Masson, Keith},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {3 (7)},
+  year          = {1971},
+  pages         = {7-8},
+}
+
+% Commented out - on closer inspection, about many things, more kind of generic column (?)
+@comment{mythlore:zuber1971,
+  title         = {Across the Brandywine},
+  url           = {https://www.jstor.org/stable/26807347},
+  author        = {Zuber, Bernie},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {3 (7)},
+  year          = {1971},
+  pages         = {11},
+}
+
+-- Mythlore. Vol. 2, No. 4 (8), Winter 1972
+-- https://www.jstor.org/stable/i26808324
+
+@article{mythlore:goodknight1972,
+  title         = {Tolkien at Eighty: An Appreciation},
+  url           = {https://www.jstor.org/stable/26808326},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {4 (8)},
+  year          = {1972},
+  pages         = {3-4},
+}
+
+@article{mythlore:marmor1972,
+  title         = {The Wielders of the Three and Other Trees},
+  url           = {https://www.jstor.org/stable/26808327},
+  author        = {Marmor, Paula},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {4 (8)},
+  year          = {1972},
+  pages         = {5-8},
+}
+
+% Commented out - on closer inspection, it appears to be some editorial column, not a Tolkien-related article.
+@comment{mythlore:goodknight1972,
+  title         = {The Counsel of Elrond},
+  url           = {https://www.jstor.org/stable/26808328},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {4 (8)},
+  year          = {1972},
+  pages         = {9},
+}
+
+% Commented out - on closer inspection, about many things, more kind of generic column (?)
+@comment{mythlore:zuber1972,
+  title         = {Across the Brandywine},
+  url           = {https://www.jstor.org/stable/26808329},
+  author        = {Zuber, Bernie},
+  journal       = {Mythlore},
+  volume        = {2},
+  number        = {4 (8)},
+  year          = {1972},
+  pages         = {10-12},
+}
+
+-- Mythlore. Vol. 3, No. 1 (9), 1973
+-- https://www.jstor.org/stable/i26808241
+
+
+% Commented out - on closer inspection, it appears to be some futuristic fan fiction
+@comment{mythlore:allan1973,
+  title         = {Genesis of _The Lord of the Rings_: A Study of Saga Development},
+  url           = {https://www.jstor.org/stable/26809849},
+  author        = {Allen, Jim},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {1 (9)},
+  year          = {1973},
+  pages         = {3-6, 8-9},
+}
+
+% Commented out - on closer inspection, about many things, more kind of generic column (?)
+@comment{mythlore:zuber1973,
+  title         = {Across the Brandywine},
+  url           = {https://www.jstor.org/stable/26809852},
+  author        = {Zuber, Bernie},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {1 (9)},
+  year          = {1973},
+  pages         = {16-19},
+}
+
+@article{mythlore:patterson1973,
+  title         = {Good News from Tolkien’s Middle Earth: Two Essays on the "Applicability" of the Lord of the Rings by Gracia-Fay Ellwood (review)},
+  url           = {https://www.jstor.org/stable/26809855},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {1 (9)},
+  year          = {1973},
+  pages         = {25-26},
+}
+
+@article{mythlore:christopher1973,
+  title         = {_Tolkien Criticism: An Annotated Checklist_ by Richard C. West (review)},
+  url           = {https://www.jstor.org/stable/26809856},
+  author        = {Christopher, Joe R.},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {1 (9)},
+  year          = {1973},
+  pages         = {26-27},
+}
+
+% Commented out - on closer inspection, it appears to be some editorial column, not a Tolkien-related article.
+@comment{mythlore:goodknight1973,
+  title         = {The Counsel of Elrond},
+  url           = {https://www.jstor.org/stable/26809859},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {1 (9)},
+  year          = {1973},
+  pages         = {30-31},
+}
+
+-- Mythlore. Vol. 3, No. 2 (10), 1975
+-- https://www.jstor.org/stable/i26808306
+
+@article{mythlore:glover1975,
+  title         = {The Christian Character of Tolkien’s Invented World},
+  url           = {https://www.jstor.org/stable/26808308},
+  author        = {Glover, Willis D.},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {2 (10)},
+  year          = {1975},
+  pages         = {3-9},
+}
+
+@article{mythlore:goodknight1975,
+  title         = {"Death and the Desire for Deathlessness": The Counsel of Elrond},
+  url           = {https://www.jstor.org/stable/26808313},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {2 (10)},
+  year          = {1975},
+  pages         = {19},
+}
+
+@article{mythlore:bisenieks1975,
+  title         = {Power and Poetry in Middle-earth},
+  url           = {https://www.jstor.org/stable/26808314},
+  author        = {Bisenieks, Dainis},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {2 (10)},
+  year          = {1975},
+  pages         = {20-24},
+}
+
+@article{mythlore:patterson1975,
+  title         = {The Tree of Tales Grows Ever Green: _Master of Middle Earth: The Fiction of J.~R.~R. Tolkien_ by Paul H. Kocher (review)},
+  url           = {https://www.jstor.org/stable/26808315},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {2 (10)},
+  year          = {1975},
+  pages         = {25-26},
+}
+
+@article{mythlore:allen1975,
+  title         = {More Tolkien Exploitation: _The Lord of the Rings, the Hobbit Notes_ by William Ready (review)},
+  url           = {https://www.jstor.org/stable/26808316},
+  author        = {Allen, Jim},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {2 (10)},
+  year          = {1975},
+  pages         = {26-27},
+}
+
+-- Mythlore. Vol. 3, No. 3 (11), March 1976
+-- https://www.jstor.org/stable/i26808206
+
+@article{mythlore:lloyd1976,
+  title         = {The Role of Warfare and Strategy in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26808208},
+  author        = {Lloyd, Paul M.},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {3 (11)},
+  year          = {1976},
+  pages         = {3-7},
+}
+
+@article{mythlore:glover1976,
+  title         = {Footnotes from The Christian Character of Tolkien’s Invented World},
+  url           = {https://www.jstor.org/stable/26808209},
+  author        = {Glover, Willis D.},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {3 (11)},
+  year          = {1976},
+  pages         = {7-8},
+}
+
+-- Mythlore, Vol. 3, No. 4 (12), June 1976
+-- https://www.jstor.org/stable/i26808282
+
+% Commented out - on closer inspection, it appears to be some futuristic fan fiction
+% The errata are probably editorial, but attributing them here to the author so it would appear closer to the corresponding article.
+@comment{mythlore:allan1976r,
+  title         = {Errata — Genesis of _The Lord of the Rings_: A Study of Saga Development},
+  url           = {https://www.jstor.org/stable/26809896},
+  author        = {Alan, Jim},
+  journal       = {Mythlore},
+  volume        = {3},
+  number        = {4 (12)},
+  year          = {1976},
+  pages         = {26},
+}
+
+-- Mythlore. Vol. 4, No. 1 (13), September 1976
+-- https://www.jstor.org/stable/i26808205
+
+@article{mythlore:lense1976,
+  title         = {Sauron is Watching "You": The Role of the Great Eye in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26808244},
+  author        = {Lense, Edward},
+  journal       = {Mythlore},
+  volume        = {4},
+  number        = {1 (13)},
+  year          = {1976},
+  pages         = {3-6},
+}
+
+@article{mythlore:patterson1976,
+  title         = {_Tolkien and the Silmarillion_ by Clyde S. Kilby (review)},
+  url           = {https://www.jstor.org/stable/26809845},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {4},
+  number        = {1 (13)},
+  year          = {1976},
+  pages         = {21-22},
+}
+
+-- Mythlore. Vol. 4, No. 2 (14), December 1976
+-- https://www.jstor.org/stable/i26811417
+
+@article{mythlore:green1976,
+  title         = {The Ring at the Centre: _Ēaca_ in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26811422},
+  author        = {Green, William H.},
+  journal       = {Mythlore},
+  volume        = {4},
+  number        = {2 (14)},
+  year          = {1976},
+  pages         = {17-19},
+}
+
+-- Mythlore. Vol. 4, No. 3 (15), March 1977
+-- https://www.jstor.org/stable/i26808220
+
+@article{mythlore:kocher1977,
+  title         = {The Tale of the Noldor},
+  url           = {https://www.jstor.org/stable/26808222},
+  author        = {Kocher, Paul H.},
+  journal       = {Mythlore},
+  volume        = {4},
+  number        = {3 (15)},
+  year          = {1977},
+  pages         = {3-8},
+}
+
+@article{mythlore:mcmenomy1977,
+  title         = {Misconstruction: _J.~R.~R. Tolkien: Architect of Middle Earth_ by Daniel Grotta-Kurska (review)},
+  url           = {https://www.jstor.org/stable/26808228},
+  author        = {McMenomy, Bruce},
+  journal       = {Mythlore},
+  volume        = {4},
+  number        = {3 (15)},
+  year          = {1977},
+  pages         = {16-17},
+}
+
+-- Mythlore. Vol. 4, No. 4 (16), June 1977
+-- https://www.jstor.org/stable/i26808283
+
+@article{mythlore:reynolds1977,
+  title         = {Poetry as Metaphor in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26808288},
+  author        = {Reynolds, William},
+  journal       = {Mythlore},
+  volume        = {4},
+  number        = {4 (16)},
+  year          = {1977},
+  pages         = {12-16},
+}
+
+-- Mythlore. Vol. 5, No. 1 (17), May 1978
+-- https://www.jstor.org/stable/i26808256
+
+@article{mythlore:walker1978,
+  title         = {The "War of the Rings" Treelogy: An Elegy for Lost Innocence and Wonder},
+  url           = {https://www.jstor.org/stable/26808258},
+  author        = {Walker, Stephen L.},
+  journal       = {Mythlore},
+  volume        = {5},
+  number        = {1 (17)},
+  year          = {1978},
+  pages         = {3-5},
+}
+
+@article{mythlore:rosenberg1978,
+  title         = {The Humanity of Sam Gamgee},
+  url           = {https://www.jstor.org/stable/26808260},
+  author        = {Rosenberg, Jerome},
+  journal       = {Mythlore},
+  volume        = {5},
+  number        = {1 (17)},
+  year          = {1978},
+  pages         = {10-11},
+}
+
+@article{mythlore:patterson1978a,
+  title         = {One Great Flower of Silver: _The Silmarillion_ by J.~ R.~ R. Tolkien, Christopher Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26808268},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {5},
+  number        = {1 (17)},
+  year          = {1978},
+  pages         = {27-28},
+}
+
+@article{mythlore:patterson1978b,
+  title         = {Toward Pearl-Dust Shores: _A Speculation on The Silmarillion_ by Jim Allan (review)},
+  url           = {https://www.jstor.org/stable/26808271},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {5},
+  number        = {1 (17)},
+  year          = {1978},
+  pages         = {29-30},
+}
+
+@article{mythlore:nelson1978,
+  title         = {Non-Human Speech: in the Fantasy of C.~S.~ Lewis, J.~ R.~ R. Tolkien, and Richard Adams},
+  url           = {https://www.jstor.org/stable/26808278},
+  author        = {Nelson, Marie},
+  journal       = {Mythlore},
+  volume        = {5},
+  number        = {1 (17)},
+  year          = {1978},
+  pages         = {37-39},
+}
+
+-- Mythlore. Vol. 5, No. 2 (18), Autumn, 1978
+-- https://www.jstor.org/stable/i26808177
+
+@article{mythlore:lynch1978,
+  title         = {The Literary Banquet and the Eucharistic Feast: Tradition in Tolkien},
+  url           = {https://www.jstor.org/stable/26808183},
+  author        = {Lynch, James},
+  journal       = {Mythlore},
+  volume        = {5},
+  number        = {2 (18)},
+  year          = {1978},
+  pages         = {13-14},
+}
+
+@article{mythlore:russell1978,
+  title         = {"The Northern Literature" and the Ring Trilogy},
+  url           = {https://www.jstor.org/stable/26808200},
+  author        = {Russell, Mariann},
+  journal       = {Mythlore},
+  volume        = {5},
+  number        = {2 (18)},
+  year          = {1978},
+  pages         = {41-42},
+}
+
+-- Mythlore. Vol. 6, No. 1 (19), Winter, 1979
+-- https://www.jstor.org/stable/i26808242
+
+@article{mythlore:noel1979,
+  title         = {Thmes, Places, Beings, Things: _The Mythology of Middle-earth_ by Ruth S. Noel (review)},
+  url           = {https://www.jstor.org/stable/26809876},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {6},
+  number        = {1 (19)},
+  year          = {1979},
+  pages         = {33-35},
+}
+
+@article{mythlore:walker1979,
+  title         = {Tolkien According to Bakshi},
+  url           = {https://www.jstor.org/stable/26809877},
+  author        = {Walker, Steven C.},
+  journal       = {Mythlore},
+  volume        = {6},
+  number        = {1 (19)},
+  year          = {1979},
+  pages         = {36},
+}
+
+@article{mythlore:ziegler1979,
+  title         = {Ring-Wrath: Or Therein Bakshi Again},
+  url           = {https://www.jstor.org/stable/26809878},
+  author        = {Ziegler, Dale},
+  journal       = {Mythlore},
+  volume        = {6},
+  number        = {1 (19)},
+  year          = {1979},
+  pages         = {37-38},
+}
+
+-- Mythlore. Vol. 6, No. 2 (20), Spring, 1979
+-- https://www.jstor.org/stable/i26808305
+
+@article{mythlore:stclair1979,
+  title         = {_The Lord of the Rings_ as Saga},
+  url           = {https://www.jstor.org/stable/26809904},
+  author        = {St. Clair, Gloriana},
+  journal       = {Mythlore},
+  volume        = {6},
+  number        = {2 (20)},
+  year          = {1979},
+  pages         = {11-16},
+}
+
+@article{mythlore:pace1979,
+  title         = {The Influence of Vergil’s _Aeneid_ on _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26809917},
+  author        = {Pace, David Paul},
+  journal       = {Mythlore},
+  volume        = {6},
+  number        = {2 (20)},
+  year          = {1979},
+  pages         = {37-38},
+}
+
+-- Mythlore. Vol. 6, No. 3 (21), Summer, 1979
+-- https://www.jstor.org/stable/i26808323
+
+@article{mythlore:goselin1979,
+  title         = {Two Faces of Eve: Galadriel and Shelob as Anima Figures},
+  url           = {https://www.jstor.org/stable/26809922},
+  author        = {Goselin, Peter Damien},
+  journal       = {Mythlore},
+  volume        = {6},
+  number        = {3 (21)},
+  year          = {1979},
+  pages         = {3-5, 28},
+}
+
+-- Mythlore. Vol. 6, No. 4 (22), Fall, 1979
+-- https://www.jstor.org/stable/i26810225
+
+@article{mythlore:oneill1979,
+  title         = {Jung in Middle-earth: _The Individuated Hobbit: Jung, Tolkien and the Archetypes of Middle-earth_ by R. Timothy O’Neill (review)},
+  url           = {https://www.jstor.org/stable/26810237},
+  author        = {Kocher, Paul H.},
+  journal       = {Mythlore},
+  volume        = {6},
+  number        = {4 (22)},
+  year          = {1979},
+  pages         = {3-5, 25-26},
+}
+
+@article{mythlore:milward1979,
+  title         = {Perchance to Touch: Tolkien as Scholar},
+  url           = {https://www.jstor.org/stable/26810243},
+  author        = {Milward, Peter},
+  journal       = {Mythlore},
+  volume        = {6},
+  number        = {4 (22)},
+  year          = {1979},
+  pages         = {31-32},
+}
+
+-- Mythlore. Vol. 7, No. 1 (23), March 1980
+-- https://www.jstor.org/stable/i26810045
+
+@article{mythlore:marchesani1980,
+  title         = {Tolkien’s Lore: The Songs of Middle-earth},
+  url           = {https://www.jstor.org/stable/26810047},
+  author        = {Marchesani, Diane},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {1 (23)},
+  year          = {1980},
+  pages         = {3-5},
+}
+
+-- Mythlore. Vol. 7, No. 2 (24), Summer 1980
+-- https://www.jstor.org/stable/i26810189
+
+@article{mythlore:gray1980,
+  title         = {Bureaucratization in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26810191},
+  author        = {Gray, Thomas},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {2 (24)},
+  year          = {1980},
+  pages         = {3-5},
+}
+
+@article{mythlore:christopher1980,
+  title         = {Three Letters by J.~R.~R. Tolkien: At the University of Texas},
+  url           = {https://www.jstor.org/stable/26810192},
+  author        = {Christopher, Joe R.},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {2 (24)},
+  year          = {1980},
+  pages         = {5},
+}
+
+% A few othe Tolkien-related articles are in this issue, but are less relevant to the bibliography.
+
+-- Mythlore. Vol. 7, No. 3 (25), Autumn 1980
+-- https://www.jstor.org/stable/i26809990
+
+@article{mythlore:walker1980,
+  title         = {The Making of a Hobbit: Tolkien’s Tantalizing Narrative Technique},
+  url           = {https://www.jstor.org/stable/26809994},
+  author        = {Walker, Steven C.},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {3 (25)},
+  year          = {1980},
+  pages         = {6-7, 37},
+}
+
+@article{mythlore:drury1980,
+  title         = {Providence at Elrond’s Council},
+  url           = {https://www.jstor.org/stable/26809995},
+  author        = {Drury, Roger},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {3 (25)},
+  year          = {1980},
+  pages         = {8-9},
+}
+
+@article{mythlore:kocher1980,
+  title         = {The Elvish Craft: _A Reader’s Guide to The Silmarillion_ by Paul H. Kocher (review)},
+  url           = {https://www.jstor.org/stable/26810005},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {3 (25)},
+  year          = {1980},
+  pages         = {31-32},
+}
+
+@article{mythlore:petty1980,
+  title         = { _One Ring to Bind Them All: Tolkien’s Mythology_ by Anne C. Petty (review)},
+  url           = {https://www.jstor.org/stable/26810008},
+  author        = {Santoski, Thomas},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {3 (25)},
+  year          = {1980},
+  pages         = {34-35},
+}
+
+@article{mythlore:morse1980,
+  title         = {Rings of Power in Plato and Tolkien},
+  url           = {https://www.jstor.org/stable/26810011},
+  author        = {Morse, Robert E.},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {3 (25)},
+  year          = {1980},
+  pages         = {38},
+}
+
+-- Mythlore. Vol. 7, No. 4 (26), Winter 1981
+-- https://www.jstor.org/stable/i26810141
+
+@article{mythlore:miller1981,
+  title         = {The Green Sun: A Study of Color in J.~R.~R. Tolkien’s _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26810143},
+  author        = {Miller, Miriam Younger},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {4 (26)},
+  year          = {1981},
+  pages         = {3-11},
+}
+
+@article{mythlore:kocher1981a,
+  title         = {_Unfinished Tales of Numenor and Middle-earth_ by J.~R.~R. Tolkien, Christopher Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26810149},
+  author        = {Kocher, Paul H.},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {4 (26)},
+  year          = {1981},
+  pages         = {31-33},
+}
+
+@article{mythlore:egan1981,
+  title         = {_The Silmarillion_ by J.~R.~R. Tolkien, Christopher Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26810151},
+  author        = {Egan, Thomas M.},
+  journal       = {Mythlore},
+  volume        = {7},
+  number        = {4 (26)},
+  year          = {1981},
+  pages         = {34-35},
+}
+
+-- Mythlore. Vol. 8, No. 1 (27), Spring 1981
+-- https://www.jstor.org/stable/i26809966
+
+@article{mythlore:barkley1981,
+  title         = {Predictability and Wonder: Familiarity and Recovery in Tolkien’s Works},
+  url           = {https://www.jstor.org/stable/26809973},
+  author        = {Barkley, Christine},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {1 (27)},
+  year          = {1981},
+  pages         = {16-18},
+}
+
+@article{mythlore:kocher1981b,
+  title         = {Túrin Turambar},
+  url           = {https://www.jstor.org/stable/26809975},
+  author        = {Kocher, Paul H.},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {1 (27)},
+  year          = {1981},
+  pages         = {22-23},
+}
+
+-- Mythlore. Vol. 8, No. 2 (28), Summer 1981
+-- https://www.jstor.org/stable/i26810090
+
+-- Commented out - on closer inspection, it appears to be some editorial column, not a Tolkien-related article.
+@comment{mythlore:goodknight1981,
+  title         = {The Counsel of Elrond: First Encounter with Tolkien},
+  url           = {https://www.jstor.org/stable/26810093},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {2 (28)},
+  year          = {1981},
+  pages         = {5},
+}
+
+@article{mythlore:rateliff1981,
+  title         = {"She" and Tolkien},
+  url           = {https://www.jstor.org/stable/26810094},
+  author        = {Rateliff, John D.},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {2 (28)},
+  year          = {1981},
+  pages         = {6-8},
+}
+
+@article{mythlore:zimmerman1981a,
+  title         = {Tolkien: A German View: _"Fantasy Literature" als Wunscherfulling und Weltdeutung_ by Dieter Petzold (review)},
+  url           = {https://www.jstor.org/stable/26810102},
+  author        = {Zimmerman, Manfred},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {2 (28)},
+  year          = {1981},
+  pages         = {18-19},
+}
+
+@article{mythlore:zimmerman1981b,
+  title         = {Rendering of Tolkien’s Alliterative Verse},
+  url           = {https://www.jstor.org/stable/26810105},
+  author        = {Zimmerman, Manfred},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {2 (28)},
+  year          = {1981},
+  pages         = {21},
+}
+
+@article{mythlore:chapman1981,
+  title         = {A Forerunner of Tolkien? Walter de la Mare’s _The Three Royal Monkeys_},
+  url           = {https://www.jstor.org/stable/26810110},
+  author        = {Chapman, Vera},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {2 (28)},
+  year          = {1981},
+  pages         = {32-34},
+}
+
+-- Mythlore. Vol. 8, No. 3 (29), Autumn 1981
+-- https://www.jstor.org/stable/i26810015
+
+@article{mythlore:kocher1981c,
+  title         = {J.~R.~R. Tolkien and George MacDonald},
+  url           = {https://www.jstor.org/stable/26810017},
+  author        = {Kocher, Paul H.},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {3 (29)},
+  year          = {1981},
+  pages         = {3-4},
+}
+
+@article{mythlore:hodge1981,
+  title         = {Tolkien: Formulas of the Past},
+  url           = {https://www.jstor.org/stable/26810022},
+  author        = {Hodge, James L.},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {3 (29)},
+  year          = {1981},
+  pages         = {15-18},
+}
+
+@article{mythlore:logan1981,
+  title         = {From "A" to "Zirak-Zigal": _The Languages of Tolkien’s Middle-Earth_ by Ruth S. Noel (review)},
+  url           = {https://www.jstor.org/stable/26810035},
+  author        = {Logan, Harry M.},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {3 (29)},
+  year          = {1981},
+  pages         = {32-33},
+}
+
+-- Mythlore. Vol. 8, No. 4 (30), Winter 1982
+-- https://www.jstor.org/stable/i26810158
+
+@article{mythlore:pitts1982,
+  title         = {The Motif of the Garden in the Novels of J.~R.~R. Tolkien, Charles Williams, and C.~S. Lewis},
+  url           = {https://www.jstor.org/stable/26810160},
+  author        = {Pitts, Mary Ellen},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {4 (30)},
+  year          = {1982},
+  pages         = {3-6, 42},
+}
+
+@article{mythlore:gillespie1982,
+  title         = {The Irish Mythological Cycle and Tolkien’s Eldar},
+  url           = {https://www.jstor.org/stable/26810162},
+  author        = {Gillespie, Gerald V.},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {4 (30)},
+  year          = {1982},
+  pages         = {8-9, 42},
+}
+
+@article{mythlore:zimmerman1982,
+  title         = {Early Glimpses of Middle-earth},
+  url           = {https://www.jstor.org/stable/26810165},
+  author        = {Zimmerman, Manfred},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {4 (30)},
+  year          = {1982},
+  pages         = {15},
+}
+
+@article{mythlore:patterson1982a,
+  title         = {There and Back Again: _Journeys of Frodo: An Atlas of J.~R.~R. Tolkien’s The Lord of the Rings_ by Barbara Strachey (review)},
+  url           = {https://www.jstor.org/stable/26810173},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {4 (30)},
+  year          = {1982},
+  pages         = {25},
+}
+
+@article{mythlore:egan1982,
+  title         = {The Wonderful World of Arda: _The Atlas of Middle-Earth_ by Karen Wynn Fonstad (review)},
+  url           = {https://www.jstor.org/stable/26810175},
+  author        = {Egan, Thomas M.},
+  journal       = {Mythlore},
+  volume        = {8},
+  number        = {4 (30)},
+  year          = {1982},
+  pages         = {26-27},
+}
+
+-- Mythlore. Vol. 9, No. 1 (31), Spring 1982
+-- https://www.jstor.org/stable/i26810119
+
+@article{mythlore:purdy1982,
+  title         = {Symbols of Immortality: A Comparison of European & Elvish Heraldry},
+  url           = {https://www.jstor.org/stable/26810126},
+  author        = {Purdy, Margaret R.},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {1 (31)},
+  year          = {1982},
+  pages         = {19-22, 36},
+}
+
+-- Mythlore. Vol. 9, No. 2 (32), Summer 1982
+-- https://www.jstor.org/stable/i26809946
+
+@article{mythlore:goodknight1982a,
+  title         = {Special Issue Focusing On: The Silmarillion Unfinished Tales The Letters of J.R.R. Tolkien},
+  url           = {https://www.jstor.org/stable/26809948},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {2 (32)},
+  year          = {1982},
+  pages         = {3-4},
+}
+
+@article{mythlore:davis1982,
+  title         = {_The Ainulindale_: Music of Creation},
+  url           = {https://www.jstor.org/stable/26809950},
+  author        = {Davis, Howard},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {2 (32)},
+  year          = {1982},
+  pages         = {6-10},
+}
+
+@article{mythlore:johnson1982,
+  title         = {The Celeblain of Celeborn and Galadriel},
+  url           = {https://www.jstor.org/stable/26809952},
+  author        = {Johnson, Janice},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {2 (32)},
+  year          = {1982},
+  pages         = {11-19},
+}
+
+@article{mythlore:goodknight1982b,
+  title         = {Tolkien in Translation},
+  url           = {https://www.jstor.org/stable/26809953},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {2 (32)},
+  year          = {1982},
+  pages         = {22-27},
+}
+
+@article{mythlore:urrutia1982,
+  title         = {Some Notes to _The Letters of J~.R.~R. Tolkien_},
+  url           = {https://www.jstor.org/stable/26809954},
+  author        = {Urrutia, Benjamin},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {2 (32)},
+  year          = {1982},
+  pages         = {28, 46},
+}
+
+@article{mythlore:goodknight1982c,
+  title         = {A Diamond from the Master: _The Old English Exodus_ by J.~R.~R. Tolkien, Joan Turville-Petre (review)},
+  url           = {https://www.jstor.org/stable/26809956},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {2 (32)},
+  year          = {1982},
+  pages         = {31},
+}
+
+@article{mythlore:crabbe1982,
+  title         = {Language and Creativity: _J.~R.~R. Tolkien_ by Katharyn F. Crabbe (review)},
+  url           = {https://www.jstor.org/stable/26809957},
+  author        = {Crabbe, Katharyn F.},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {2 (32)},
+  year          = {1982},
+  pages         = {31-32},
+}
+
+@article{mythlore:patterson1982b,
+  title         = {Edwardian, Philologist, Christian, Genius: _England and Always: Tolkien’s World of the Rings_ by Jared Lobdell (review)},
+  url           = {https://www.jstor.org/stable/26809958},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {2 (32)},
+  year          = {1982},
+  pages         = {32-34},
+}
+
+-- Mythlore. Vol. 9, No. 3 (33), Autumn 1982
+-- https://www.jstor.org/stable/i26810067
+
+@article{mythlore:hennelly1982,
+  title         = {The Road and the Ring: Solid Geometry in Tolkien’s Middle-earth},
+  url           = {https://www.jstor.org/stable/26810069},
+  author        = {Hennelly, Mark M.},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {3 (33)},
+  year          = {1982},
+  pages         = {3-13},
+}
+
+@article{mythlore:hyde1982,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810071},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {3 (33)},
+  year          = {1982},
+  pages         = {14-15, 30},
+}
+
+-- Mythlore. Vol. 9, No. 4 (34), Winter 1983
+-- https://www.jstor.org/stable/i26810771
+
+@article{mythlore:ho1983,
+  title         = {The Childlike Hobbit},
+  url           = {https://www.jstor.org/stable/26811470},
+  author        = {Ho, Tisa},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {4 (34)},
+  year          = {1983},
+  pages         = {3-9},
+}
+
+@article{mythlore:hyde1983a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26811476},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {4 (34)},
+  year          = {1983},
+  pages         = {19-20, 32},
+}
+
+@article{mythlore:zimmerman1983,
+  title         = {The Origin of Gandalf and Josef Madlener},
+  url           = {https://www.jstor.org/stable/26811478},
+  author        = {Zimmerman, Manfred},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {4 (34)},
+  year          = {1983},
+  pages         = {22, 24-25},
+}
+
+@article{mythlore:yates1983,
+  title         = {The Road Goes Ever On: _The Road to Middle-Earth_ by T.~A. Shippey (review)},
+  url           = {https://www.jstor.org/stable/26811489},
+  author        = {Yates, Jessica},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {4 (34)},
+  year          = {1983},
+  pages         = {38-40},
+}
+
+@article{mythlore:brunsdale1983,
+  title         = {Norse Mythological Elements in _The Hobbit_},
+  url           = {https://www.jstor.org/stable/26811495},
+  author        = {Brunsdale, Mitzi M.},
+  journal       = {Mythlore},
+  volume        = {9},
+  number        = {4 (34)},
+  year          = {1983},
+  pages         = {49-50, 55},
+}
+
+-- Mythlore. Vol. 10, No. 1 (35), Spring 1983
+-- https://www.jstor.org/stable/i26810614
+
+@article{mythlore:patterson1983,
+  title         = {Bright-Eyed Beauty: Celtic Elements in Charles Williams, J.~R.~R. Tolkien, and C.~S. Lewis},
+  url           = {https://www.jstor.org/stable/26810618},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {1 (35)},
+  year          = {1983},
+  pages         = {5-10},
+}
+
+@article{mythlore:schmiel1983,
+  title         = {In The Forge of Los: Tolkien and the Art of Creative Fantasy},
+  url           = {https://www.jstor.org/stable/26810620},
+  author        = {Schmiel, Mary Aileen},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {1 (35)},
+  year          = {1983},
+  pages         = {17-22},
+}
+
+@article{mythlore:hyde1983b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810623},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {1 (35)},
+  year          = {1983},
+  pages         = {27-29, 50},
+}
+
+@article{mythlore:agoy1983,
+  title         = {The Degradation of "IS": _The Shores of Middle-earth_ by Robert Giddings, Elizabeth Holland (review)},
+  url           = {https://www.jstor.org/stable/26810626},
+  author        = {Agøy, Nils Ivar},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {1 (35)},
+  year          = {1983},
+  pages         = {35-37},
+}
+
+@article{mythlore:swycaffer1983,
+  title         = {Historical Motivations: for the Siege of Minas Tirith},
+  url           = {https://www.jstor.org/stable/26810634},
+  author        = {Swycaffer, Jefferson P.},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {1 (35)},
+  year          = {1983},
+  pages         = {47-49},
+}
+
+-- Mythlore. Vol. 10, No. 2 (36), Summer 1983
+-- https://www.jstor.org/stable/i26810737
+
+@article{mythlore:crowe1983,
+  title         = {The Many Faces of Heroism in Tolkien},
+  url           = {https://www.jstor.org/stable/26810743},
+  author        = {Crowe, Edith L.},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {2 (36)},
+  year          = {1983},
+  pages         = {5-8},
+}
+
+@article{mythlore:manganiello1983,
+  title         = {The Artist as Magician: Yeats, Joyce, and Tolkien},
+  url           = {https://www.jstor.org/stable/26810745},
+  author        = {Manganiello, Dominic},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {2 (36)},
+  year          = {1983},
+  pages         = {13-15, 25-26},
+}
+
+@article{mythlore:hyde1983c,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810748},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {2 (36)},
+  year          = {1983},
+  pages         = {19-20, 50},
+}
+
+@article{mythlore:schorr1983,
+  title         = {The Nature of Dreams: in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26810749},
+  author        = {Schorr, Karl},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {2 (36)},
+  year          = {1983},
+  pages         = {21, 46},
+}
+
+-- Mythlore. Vol. 10, No. 3 (37), Winter 1984
+-- https://www.jstor.org/stable/i26810562
+
+@article{mythlore:hall1984,
+  title         = {Silent Commands? Frodo and Gollum at the Cracks of Doom},
+  url           = {https://www.jstor.org/stable/26810565},
+  author        = {Hall, Robert A.},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {3 (37)},
+  year          = {1984},
+  pages         = {5-7},
+}
+
+@article{mythlore:stoddard1984,
+  title         = {A Critical Approach to Fantasy with Application to _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26810566},
+  author        = {Stoddard, William},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {3 (37)},
+  year          = {1984},
+  pages         = {8-13},
+}
+
+@article{mythlore:callaway1984,
+  title         = {Gollum: A Misunderstood Hero},
+  url           = {https://www.jstor.org/stable/26810567},
+  author        = {Callaway, David},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {3 (37)},
+  year          = {1984},
+  pages         = {14-17, 22},
+}
+
+@article{mythlore:bartlett1984,
+  title         = {Invasion from Eternity: Time and Myth in Middle-earth},
+  url           = {https://www.jstor.org/stable/26810568},
+  author        = {Bartlett, Sally},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {3 (37)},
+  year          = {1984},
+  pages         = {18-22},
+}
+
+@article{mythlore:kocher1984,
+  title         = {The Drúedain},
+  url           = {https://www.jstor.org/stable/26810569},
+  author        = {Kocher, Paul H.},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {3 (37)},
+  year          = {1984},
+  pages         = {23-25},
+}
+
+@article{mythlore:donahue1984,
+  title         = {A Linguist Looks at Tolkien’s Elvish},
+  url           = {https://www.jstor.org/stable/26810573},
+  author        = {Donahue, Thomas S.},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {3 (37)},
+  year          = {1984},
+  pages         = {28-31},
+}
+
+@article{mythlore:walker1984,
+  title         = {The Little Kingdom: Some Considerations and a Map},
+  url           = {https://www.jstor.org/stable/26810581},
+  author        = {Walker, R. C.},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {3 (37)},
+  year          = {1984},
+  pages         = {47-48},
+}
+
+-- Mythlore. Vol. 10, No. 4 (38), Spring 1984
+-- https://www.jstor.org/stable/i26810710
+
+@article{mythlore:rawls1984a,
+  title         = {The Feminine Principle in Tolkien},
+  url           = {https://www.jstor.org/stable/26810713},
+  author        = {Rawls, Melanie A.},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {4 (38)},
+  year          = {1984},
+  pages         = {5-13, 45},
+}
+
+@article{mythlore:lowentrout1984,
+  title         = {The Evocation of Good in Tolkien},
+  url           = {https://www.jstor.org/stable/26810720},
+  author        = {Lowentrout, Peter},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {4 (38)},
+  year          = {1984},
+  pages         = {32-33},
+}
+
+@article{mythlore:hyde1984a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810721},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {10},
+  number        = {4 (38)},
+  year          = {1984},
+  pages         = {34-37, 47},
+}
+
+-- Mythlore. Vol. 11, No. 1 (39), Summer 1984
+-- https://www.jstor.org/stable/i26810534
+
+@article{mythlore:houghton1984,
+  title         = {Rochester The Renewer: The Byronic Hero and The Messiah as Elements in The King Elessar},
+  url           = {https://www.jstor.org/stable/26810539},
+  author        = {Houghton, John Wm.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {13-17, 45},
+}
+
+@article{mythlore:hyde1984b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810542},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {21-22},
+}
+
+@article{mythlore:paxson1984,
+  title         = {The Tolkien Tradition},
+  url           = {https://www.jstor.org/stable/26810543},
+  author        = {Paxson, Diana L.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {23-27, 37},
+}
+
+@article{mythlore:yates1984a,
+  title         = {The Search Continues: _The Book of Lost Tales, Part I_ by J.~R.~R. Tolkien, Christopher R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26810545},
+  author        = {Yates, Jessica},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {29-30},
+}
+
+@article{mythlore:egan1984a,
+  title         = {Something from the Attic: _The Book of Lost Tales Part I_ ("The History of Middle-earth") by J.~R.~R. Tolkien, Christopher R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26810546},
+  author        = {Egan, Thomas M.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {30-32},
+}
+
+@article{mythlore:patterson1984,
+  title         = {All About Light: _Splintered Light: Logos and Language in Tolkien’s World_ by Verlyn Flieger (review)},
+  url           = {https://www.jstor.org/stable/26810547},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {32-33},
+}
+
+@article{mythlore:egan1984b,
+  title         = {Fragmentary Glimpses: _Finn and Hengest: The Fragment and the Episode_ by J.~R.~R. Tolkien, Alan Bliss (review)},
+  url           = {https://www.jstor.org/stable/26810553},
+  author        = {Egan, Thomas M.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {36-37},
+}
+
+@article{mythlore:harrod1984,
+  title         = {Trees in Tolkien, and What Happened Under Them},
+  url           = {https://www.jstor.org/stable/26810558},
+  author        = {Harrod, Elizabeth},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {47-52, 58},
+}
+
+@article{mythlore:berman1984,
+  title         = {Dragons for Tolkien and Lewis},
+  url           = {https://www.jstor.org/stable/26810559},
+  author        = {Berman, Ruth},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {1 (39)},
+  year          = {1984},
+  pages         = {53-58},
+}
+
+-- Mythlore. Vol. 11, No. 2 (40), Autumn 1984
+-- https://www.jstor.org/stable/i26810664
+
+@article{mythlore:ryan1984,
+  title         = {Uncouth Innocence: Some Links Between Chrétien de Troyes, Wolfram von Eschenbach and J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26810668},
+  author        = {Ryan, J. S.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {2 (40)},
+  year          = {1984},
+  pages         = {8-14, 27},
+}
+
+@article{mythlore:rawls1984b,
+  title         = {The Rings of Power},
+  url           = {https://www.jstor.org/stable/26810674},
+  author        = {Rawls, Melanie A.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {2 (40)},
+  year          = {1984},
+  pages         = {29-32},
+}
+
+@article{mythlore:hyde1984,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810675},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {2 (40)},
+  year          = {1984},
+  pages         = {34-36},
+}
+
+@article{mythlore:yates1984b,
+  title         = {Provocative and Infuriating: _J.~R.~R. Tolkien: This Far Land_ by Robert Giddings (review)},
+  url           = {https://www.jstor.org/stable/26810678},
+  author        = {Yates, Jessica},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {2 (40)},
+  year          = {1984},
+  pages         = {51-53},
+}
+
+@article{mythlore:beach1984,
+  title         = {Working Sketches: _The Book of Lost Tales Part II_ by J.~R.~R. Tolkien, Christopher Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26810679},
+  author        = {Beach, Sarah},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {2 (40)},
+  year          = {1984},
+  pages         = {53},
+}
+
+@article{mythlore:egan1984c,
+  title         = {Essays of Greatness: _The Monsters and the Critics, and Other Essays_ by J.~R.~R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26810680},
+  author        = {Egan, Thomas M.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {2 (40)},
+  year          = {1984},
+  pages         = {53-54},
+}
+
+@article{mythlore:thompson1984,
+  title         = {Early Review of Books by J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26810683},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {2 (40)},
+  year          = {1984},
+  pages         = {56-60},
+}
+
+-- Mythlore. Vol. 11, No. 3 (41), Winter-Spring 1985
+-- https://www.jstor.org/stable/i26810586
+
+@article{mythlore:bullock1985,
+  title         = {The Importance of Free Will in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26810596},
+  author        = {Bullock, Richard P.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {3 (41)},
+  year          = {1985},
+  pages         = {29, 56},
+}
+
+@article{mythlore:zimmerman1985,
+  title         = {Miscellaneous Remarks: On Gimli and On Rhythmic Prose},
+  url           = {https://www.jstor.org/stable/26810598},
+  author        = {Zimmerman, Manfred},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {3 (41)},
+  year          = {1985},
+  pages         = {32},
+}
+
+@article{mythlore:hall1985,
+  title         = {Who is The Master of The "Precious"?},
+  url           = {https://www.jstor.org/stable/26810600},
+  author        = {Hall, Robert A.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {3 (41)},
+  year          = {1985},
+  pages         = {34-36},
+}
+
+@article{mythlore:patterson1985,
+  title         = {A Dedication Appreciated: _J.~R.~R. Tolkien — Myth, Morality and Religion_ by Richard L. Purtill (review)},
+  url           = {https://www.jstor.org/stable/26810603},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {3 (41)},
+  year          = {1985},
+  pages         = {39},
+}
+
+@article{mythlore:hyde1985a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810607},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {3 (41)},
+  year          = {1985},
+  pages         = {42-45},
+}
+
+@article{mythlore:thompson1985a,
+  title         = {Early Review of Books by J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26810611},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {11},
+  number        = {3 (41)},
+  year          = {1985},
+  pages         = {59-63},
+}
+
+-- Mythlore. Vol. 11, No. 4 (42), Summer 1985
+-- https://www.jstor.org/stable/i26810734
+
+% This issue does have any articles.
+
+-- Mythlore. Vol. 12, No. 1 (43), Autumn 1985
+-- https://www.jstor.org/stable/i26810689
+
+@article{mythlore:sammons1985,
+  title         = {Tolkien On Fantasy in _Smith of Wootton Major_},
+  url           = {https://www.jstor.org/stable/26810691},
+  author        = {Sammons, Margaret},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {1 (43)},
+  year          = {1985},
+  pages         = {3-7, 37},
+}
+
+@article{mythlore:rawls1985,
+  title         = {Arwen, Shadow Bride},
+  url           = {https://www.jstor.org/stable/26810694},
+  author        = {Rawls, Melanie A.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {1 (43)},
+  year          = {1985},
+  pages         = {24-25, 37},
+}
+
+@article{mythlore:hyde1985b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810695},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {1 (43)},
+  year          = {1985},
+  pages         = {26-27, 42},
+}
+
+@article{mythlore:egan1985,
+  title         = {Tolkien and Chesterton: Some Analogies},
+  url           = {https://www.jstor.org/stable/26810696},
+  author        = {Egan, Thomas M.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {1 (43)},
+  year          = {1985},
+  pages         = {28-35},
+}
+
+@article{mythlore:kocher1985,
+  title         = {Ilúvatar and The Secret Fire},
+  url           = {https://www.jstor.org/stable/26810697},
+  author        = {Kocher, Paul H.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {1 (43)},
+  year          = {1985},
+  pages         = {36-37},
+}
+
+@article{mythlore:ryan1985,
+  title         = {Saruman, "Sharkey" and Suruman: Analagous Figures of Eastern Ingenuity and Cunning},
+  url           = {https://www.jstor.org/stable/26810704},
+  author        = {Ryan, J. S.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {1 (43)},
+  year          = {1985},
+  pages         = {43-44, 57},
+}
+
+@article{mythlore:thompson1985b,
+  title         = {Early Review of Books by J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26810708},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {1 (43)},
+  year          = {1985},
+  pages         = {58-63},
+}
+
+-- Mythlore. Vol. 12, No. 2 (44), Winter 1985
+-- https://www.jstor.org/stable/i26810533
+
+% This issue does have any articles.
+
+-- Mythlore. Vol. 12, No. 3 (45), Spring 1986
+-- https://www.jstor.org/stable/i26810638
+
+@article{mythlore:schakel1986,
+  title         = {Dance as Metaphor and Myth: in Lewis, Tolkien, and Williams},
+  url           = {https://www.jstor.org/stable/26810642},
+  author        = {Schakel, Peter J.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {3 (45)},
+  year          = {1986},
+  pages         = {4-8, 23},
+}
+
+@article{mythlore:beach1986,
+  title         = {The Masque of the Silmarils},
+  url           = {https://www.jstor.org/stable/26810645},
+  author        = {Beach, Sarah},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {3 (45)},
+  year          = {1986},
+  pages         = {11-16},
+}
+
+@article{mythlore:hyde1986a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26810646},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {3 (45)},
+  year          = {1986},
+  pages         = {17-18, 23},
+}
+
+@article{mythlore:deyo1986,
+  title         = {Niggle’s Leaves: The Red Book of Westmarch and Related Minor Poetry of J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26810649},
+  author        = {Deyo, Steven M.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {3 (45)},
+  year          = {1986},
+  pages         = {28-37},
+}
+
+@article{mythlore:rateliff1986,
+  title         = {"And Something Yet Remains to Be Said": Tolkien and Williams},
+  url           = {https://www.jstor.org/stable/26810654},
+  author        = {Rateliff, John D.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {3 (45)},
+  year          = {1986},
+  pages         = {48-54},
+}
+
+@article{mythlore:yates1986,
+  title         = {Romantic Gestes: _The Lays of Beleriand_ by J.~R.~R. Tolkien, Christopher R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26810656},
+  author        = {Yates, Jessica},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {3 (45)},
+  year          = {1986},
+  pages         = {55-56},
+}
+
+@article{mythlore:thompson1986a,
+  title         = {Early Review of Books by J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26810661},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {3 (45)},
+  year          = {1986},
+  pages         = {61-62},
+}
+
+-- Mythlore. Vol. 12, No. 4 (46), Summer 1986
+-- https://www.jstor.org/stable/i26812313
+
+% The errata are probably editorial, but attributing them here to the author so it would appear closer to the corresponding article.
+@article{mythlore:hyde1986r,
+  title         = {Errata — _Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812987},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {4 (46)},
+  year          = {1986},
+  pages         = {15},
+}
+
+@article{mythlore:harvey1986,
+  title         = {Imaginary but Powerful: _The Song of Middle-earth_ by David Harvey (review)},
+  url           = {https://www.jstor.org/stable/26813003},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {4 (46)},
+  year          = {1986},
+  pages         = {37},
+}
+
+
+@article{mythlore:thompson1986b,
+  title         = {Early Review of Books by J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26813021},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {12},
+  number        = {4 (46)},
+  year          = {1986},
+  pages         = {59-62},
+}
+
+-- Mythlore. Vol. 13, No. 1 (47), Autumn 1986
+-- https://www.jstor.org/stable/i26811031
+
+@article{mythlore:hargrove1986,
+  title         = {Who is Tom Bombadil?},
+  url           = {https://www.jstor.org/stable/26812903},
+  author        = {Hargrove, Gene},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {1 (47)},
+  year          = {1986},
+  pages         = {20-24},
+}
+
+@article{mythlore:hyde1986b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812906},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {1 (47)},
+  year          = {1986},
+  pages         = {30-32},
+}
+
+@article{mythlore:bratman1986,
+  title         = {_The Politics of Fantasy: C.~S. Lewis and J.~R.~R. Tolkien_ by Lee D. Rossi (review)},
+  url           = {https://www.jstor.org/stable/26812911},
+  author        = {Bratman, David},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {1 (47)},
+  year          = {1986},
+  pages         = {42-43},
+}
+
+@article{mythlore:thompson1986c,
+  title         = {Early Review of Books by J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26812921},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {1 (47)},
+  year          = {1986},
+  pages         = {54-59},
+}
+
+-- Mythlore. Vol. 13, No. 2 (48), Winter 1986
+-- https://www.jstor.org/stable/i26812120
+
+@article{mythlore:boenig1986,
+  title         = {Tolkien and Old Germanic Ethics},
+  url           = {https://www.jstor.org/stable/26812294},
+  author        = {Boenig, Robert},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {2 (48)},
+  year          = {1986},
+  pages         = {9-12, 40},
+}
+
+@article{mythlore:hyde1986c,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812296},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {2 (48)},
+  year          = {1986},
+  pages         = {22-24},
+}
+
+@article{mythlore:mende1986,
+  title         = {Gondolin, Minas Tirith and the Eucatastrophe},
+  url           = {https://www.jstor.org/stable/26812299},
+  author        = {Mende, Lisa Anne},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {2 (48)},
+  year          = {1986},
+  pages         = {37-40},
+}
+
+@article{mythlore:goodknight1986,
+  title         = {Treasures in the Light: _The Shaping of Middle-earth: The Quenta, The Ambarkanta and The Annals_, together with the earliest "Silmarillion" and the First Map. Volume IV of _The History of Middle-earth_ by J.~R.~R. Tolkien, Christopher Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26812301},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {2 (48)},
+  year          = {1986},
+  pages         = {45},
+}
+
+-- Mythlore. Vol. 13, No. 3 (49), Spring 1987
+-- https://www.jstor.org/stable/i26810959
+
+@article{mythlore:lindsay1987,
+  title         = {The Dream System in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26810961},
+  author        = {Lindsay, Sean},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {3 (49)},
+  year          = {1987},
+  pages         = {7-14},
+}
+
+@article{mythlore:hyde1987a,
+  title         = {"Gandalf, Please Should Not Sputter"},
+  url           = {https://www.jstor.org/stable/26810963},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {3 (49)},
+  year          = {1987},
+  pages         = {20-28},
+}
+
+@article{mythlore:patterson1987,
+  title         = {Mandalas by Tolkienn: _The Shaping of Middle-earth: The Quenta, the Ambarkanta and the Annals_ by J.~R.~R. Tolkien, Christopher R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26810968},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {3 (49)},
+  year          = {1987},
+  pages         = {39},
+}
+
+@article{mythlore:thompson1987a,
+  title         = {Early Articles, Comments, Etcetera about J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26810979},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {3 (49)},
+  year          = {1987},
+  pages         = {58-63},
+}
+
+-- Mythlore. Vol. 13, No. 4 (50), Summer 1987
+-- https://www.jstor.org/stable/i26812046
+
+@article{mythlore:wytenbroek1987,
+  title         = {Rites of Passage in _The Hobbit_},
+  url           = {https://www.jstor.org/stable/26812050},
+  author        = {Wytenbroek, J. R.},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {4 (50)},
+  year          = {1987},
+  pages         = {5-8, 40},
+}
+
+@article{mythlore:hyles1987,
+  title         = {On the Nature of Evil: The Cosmic Myths of Lewis, Tolkien & Williams},
+  url           = {https://www.jstor.org/stable/26812051},
+  author        = {Hyles, Vernon},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {4 (50)},
+  year          = {1987},
+  pages         = {9-13, 17},
+}
+
+@article{mythlore:filmer1987,
+  title         = {An Allegory Unveiled: A Reading of _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26812055},
+  author        = {Filmer, Kath},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {4 (50)},
+  year          = {1987},
+  pages         = {19-21},
+}
+
+@article{mythlore:agoy1987,
+  title         = {A Nodal Structure in Tolkien’s Tales of the First Age?},
+  url           = {https://www.jstor.org/stable/26812056},
+  author        = {Agøy, Nils Ivar},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {4 (50)},
+  year          = {1987},
+  pages         = {22-25},
+}
+
+@article{mythlore:hyde1987b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812071},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {13},
+  number        = {4 (50)},
+  year          = {1987},
+  pages         = {43-47, 62},
+}
+
+-- Mythlore. Vol. 14, No. 1 (51), Autumn 1987
+-- https://www.jstor.org/stable/i26811877
+
+@article{mythlore:evans1987,
+  title         = {Tolkien’s World-Creation: Degenerative Recurrence},
+  url           = {https://www.jstor.org/stable/26811906},
+  author        = {Evans, Robley},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {1 (51)},
+  year          = {1987},
+  pages         = {5-8, 47},
+}
+
+@article{mythlore:couch1987,
+  title         = {From Under Mountains to Beyond Stars: The Process of Riddling in Leofric’s _The Exeter Book_ and _The Hobbit_},
+  url           = {https://www.jstor.org/stable/26811907},
+  author        = {Couch, Christopher L.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {1 (51)},
+  year          = {1987},
+  pages         = {9-13, 55},
+}
+
+@article{mythlore:hyde1987c,
+  title         = {J.~R.~R. Tolkien: Creative Uses of the Oxford English Dictionary},
+  url           = {https://www.jstor.org/stable/26811910},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {1 (51)},
+  year          = {1987},
+  pages         = {20-24, 56},
+}
+
+@article{mythlore:hammond1987,
+  title         = {All the Comforts: The Image of Home in _The Hobbit_ & _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26811913},
+  author        = {Hammond, Wayne G.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {1 (51)},
+  year          = {1987},
+  pages         = {29-33},
+}
+
+@article{mythlore:loback1987,
+  title         = {The Kindreds, Houses & Population of the Elves during the First Age},
+  url           = {https://www.jstor.org/stable/26811914},
+  author        = {Loback, Tom},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {1 (51)},
+  year          = {1987},
+  pages         = {34-38, 56},
+}
+
+@article{mythlore:thompson1987b,
+  title         = {Minor, Early References to Tolkien and His Works},
+  url           = {https://www.jstor.org/stable/26811917},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {1 (51)},
+  year          = {1987},
+  pages         = {41-42, 55},
+}
+
+@article{mythlore:irwin1987,
+  title         = {Archaic Pronouns in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26811919},
+  author        = {Irwin, Betty J.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {1 (51)},
+  year          = {1987},
+  pages         = {46-47},
+}
+
+@article{mythlore:higbie1987,
+  title         = {Frodo and Childe Roland},
+  url           = {https://www.jstor.org/stable/26811931},
+  author        = {Higbie, Robert and Bryan, Joe E.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {1 (51)},
+  year          = {1987},
+  pages         = {57},
+}
+
+-- Mythlore. Vol. 14, No. 2 (52), Winter 1987
+-- https://www.jstor.org/stable/i26812045
+
+@article{mythlore:hood1987,
+  title         = {Sauron and Dracula},
+  url           = {https://www.jstor.org/stable/26812930},
+  author        = {Hood, Gwenyth},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {2 (52)},
+  year          = {1987},
+  pages         = {11-17, 56},
+}
+
+@article{mythlore:santoski1987,
+  title         = {Language to Mythology to World: A Subjective Review of _The Lost Road and Other Writings_, Volume V in The History of Middle-earth},
+  url           = {https://www.jstor.org/stable/26812938},
+  author        = {Santoski, Taum},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {2 (52)},
+  year          = {1987},
+  pages         = {41-42},
+}
+
+@article{mythlore:scull1987,
+  title         = {The Hobbit considered in relation to Children’s Literature: Contemporary with its Writing and Publication},
+  url           = {https://www.jstor.org/stable/26812947},
+  author        = {Scull, Christina},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {2 (52)},
+  year          = {1987},
+  pages         = {49-56},
+}
+
+@article{mythlore:hyde1987d,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812948},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {2 (52)},
+  year          = {1987},
+  pages         = {57-62},
+}
+
+-- Mythlore. Vol. 14, No. 3 (53), Spring 1988
+-- https://www.jstor.org/stable/i26810981
+
+@article{mythlore:reckford1988,
+  title         = {"There and Back Again" — Odysseus and Bilbo Baggins},
+  url           = {https://www.jstor.org/stable/26811011},
+  author        = {Reckford, Kenneth J.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {3 (53)},
+  year          = {1988},
+  pages         = {5-9},
+}
+
+@article{mythlore:greenman1988,
+  title         = {_The Silmarillion_ as Aristotelian Epic-Tragedy},
+  url           = {https://www.jstor.org/stable/26811014},
+  author        = {Greenman, David},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {3 (53)},
+  year          = {1988},
+  pages         = {20-25, 42},
+}
+
+@article{mythlore:madsen1988,
+  title         = {Light from an Invisible Lamp: Natural Religion in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26811021},
+  author        = {Madsen, Catherine},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {3 (53)},
+  year          = {1988},
+  pages         = {43-47},
+}
+
+@article{mythlore:hyde1988a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26811022},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {3 (53)},
+  year          = {1988},
+  pages         = {48-51},
+}
+
+@article{mythlore:boenig1988,
+  title         = {The Drums of Doom: H.~G. Wells’ First Men in the Moon and _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26811027},
+  author        = {Boenig, Robert},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {3 (53)},
+  year          = {1988},
+  pages         = {57-58},
+}
+
+@article{mythlore:deyo1988,
+  title         = {Wyrd and Will: Fate, Fatalism and Free Will in the Northern Elegy and J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26811029},
+  author        = {Deyo, Steven M.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {3 (53)},
+  year          = {1988},
+  pages         = {59-62},
+}
+
+-- Mythlore. Vol. 14, No. 4 (54), Summer 1988
+-- https://www.jstor.org/stable/i26812077
+
+@article{mythlore:wytenbroek1988,
+  title         = {Apocalyptic Vision in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26812955},
+  author        = {Wytenbroek, J. R.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {4 (54)},
+  year          = {1988},
+  pages         = {7-12},
+}
+
+@article{mythlore:edmunds1988,
+  title         = {Echoes in Age: From the World of J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26812961},
+  author        = {Edmunds, E. L.},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {4 (54)},
+  year          = {1988},
+  pages         = {19-26, 32},
+}
+
+@article{mythlore:hyde1988b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812965},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {14},
+  number        = {4 (54)},
+  year          = {1988},
+  pages         = {39-42},
+}
+
+-- Mythlore. Vol. 15, No. 1 (55), Autumn 1988
+-- https://www.jstor.org/stable/i26812340
+
+@article{mythlore:aldrich1988,
+  title         = {The Sense of Time in J.~R.~R. Tolkien’s _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26812363},
+  author        = {Aldrich, Kevin},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {1 (55)},
+  year          = {1988},
+  pages         = {5-9},
+}
+
+@article{mythlore:hyde1988c,
+  title         = {The Laborer-Asthete: Tengwar on the Title Page},
+  url           = {https://www.jstor.org/stable/26818574},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {1 (55)},
+  year          = {1988},
+  pages         = {22},
+}
+
+@article{mythlore:hyde1988d,
+  title         = {A Philologist at the North Pole: J.~R.~R. Tolkien and _The Father Christmas Letters_},
+  url           = {https://www.jstor.org/stable/26812367},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {1 (55)},
+  year          = {1988},
+  pages         = {23-27},
+}
+
+@article{mythlore:goodknight1988,
+  title         = {A Superb Hobbit: _The Annotated Hobbit_ by J.~R.~R. Tolkien, Douglas Anderson (review)},
+  url           = {https://www.jstor.org/stable/26812369},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {1 (55)},
+  year          = {1988},
+  pages         = {32},
+}
+
+@article{mythlore:christopher1988a,
+  title         = {J.~R.~R. Tolkien, Narnian Exile},
+  url           = {https://www.jstor.org/stable/26812375},
+  author        = {Christopher, Joe R.},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {1 (55)},
+  year          = {1988},
+  pages         = {37-45},
+}
+
+@article{mythlore:harris1988,
+  title         = {The Psychology of Power: in Tolkien’s _The Lord of the Rings_, Orwell’s _1984_ and Le Guin’s _A Wizard of Earthsea_},
+  url           = {https://www.jstor.org/stable/26812377},
+  author        = {Harris, Mason},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {1 (55)},
+  year          = {1988},
+  pages         = {46-56},
+}
+
+@article{mythlore:blackburn1988,
+  title         = {"Dangerous as a Guide to Deeds": Politics in the Fiction of J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26812382},
+  author        = {Blackburn, William},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {1 (55)},
+  year          = {1988},
+  pages         = {62-66},
+}
+
+-- Mythlore. Vol. 15, No. 2 (56), Winter 1988
+-- https://www.jstor.org/stable/i26812008
+
+@article{mythlore:thompson1988,
+  title         = {_The Hobbit_ as a Part of The Red Book of Westmarch},
+  url           = {https://www.jstor.org/stable/26812028},
+  author        = {Thompson, Kristin},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {2 (56)},
+  year          = {1988},
+  pages         = {11-16},
+}
+
+@article{mythlore:christopher1988b,
+  title         = {J.~R.~R. Tolkien: Narnian Exile — Part II},
+  url           = {https://www.jstor.org/stable/26812029},
+  author        = {Christopher, Joe R.},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {2 (56)},
+  year          = {1988},
+  pages         = {17-23},
+}
+
+@article{mythlore:hyde1988e,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812035},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {2 (56)},
+  year          = {1988},
+  pages         = {47-52},
+}
+
+@article{mythlore:treloar1988,
+  title         = {Tolkien and Christian Concepts of Evil: Apocalypse and Privation},
+  url           = {https://www.jstor.org/stable/26812039},
+  author        = {Treloar, John L.},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {2 (56)},
+  year          = {1988},
+  pages         = {57-60},
+}
+
+-- Mythlore. Vol. 15, No. 3 (57), Spring 1989
+-- https://www.jstor.org/stable/i26812276
+
+@article{mythlore:christensen1989,
+  title         = {Tolkien’s Creative Technique: _Beowulf_ and _The Hobbit_},
+  url           = {https://www.jstor.org/stable/26812317},
+  author        = {Christensen, Bonniejean},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {3 (57)},
+  year          = {1989},
+  pages         = {4-10},
+}
+
+@article{mythlore:hyde1989a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812325},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {3 (57)},
+  year          = {1989},
+  pages         = {31-36},
+}
+
+@article{mythlore:bentinck1989,
+  title         = {Tolkien and De La Mare: The Fantastic Secondary Worlds of _The Hobbit_ and _The Three Mulla-Mulgars_},
+  url           = {https://www.jstor.org/stable/26812327},
+  author        = {Bentinck, A.},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {3 (57)},
+  year          = {1989},
+  pages         = {39-43},
+}
+
+@article{mythlore:patterson1989,
+  title         = {Mythopoeia Etc.: _Tree and Leaf_, including the poem _Mythopoeia_ by J.~R.~R. Tolkien, Christopher R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26812328},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {3 (57)},
+  year          = {1989},
+  pages         = {44},
+}
+
+@article{mythlore:hammond1989a,
+  title         = {Tolkien Sighs: _J.~R.~R. Tolkien: Man of Fantasy_ by Russell Shorto, G.~B. Tennyson, Bill Negron (review)},
+  url           = {https://www.jstor.org/stable/26812332},
+  author        = {Hammond, Wayne G.},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {3 (57)},
+  year          = {1989},
+  pages         = {48-49},
+}
+
+-- Mythlore. Vol. 15, No. 4 (58), Summer 1989
+-- https://www.jstor.org/stable/i26811915
+
+@article{mythlore:burns1989,
+  title         = {J.~R.~R. Tolkien and the Journey North},
+  url           = {https://www.jstor.org/stable/26811938},
+  author        = {Burns, Marjorie J.},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {4 (58)},
+  year          = {1989},
+  pages         = {5-9},
+}
+
+@article{mythlore:hyde1989b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26811942},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {4 (58)},
+  year          = {1989},
+  pages         = {26-30, 57},
+}
+
+@article{mythlore:beach1989,
+  title         = {"A Myth for Angel-Land": J.~R.~R. Tolkien and Creative Mythology},
+  url           = {https://www.jstor.org/stable/26811943},
+  author        = {Beach, Sarah},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {4 (58)},
+  year          = {1989},
+  pages         = {31-36},
+}
+
+@article{mythlore:hammond1989b,
+  title         = {Casting Important Shadows: _The Return of the Shadow: The History of The Lord of the Rings, Part One; The History of Middle-earth, Volume VI_ by J.~R.~R. Tolkien, Christopher R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26811949},
+  author        = {Hammond, Wayne G.},
+  journal       = {Mythlore},
+  volume        = {15},
+  number        = {4 (58)},
+  year          = {1989},
+  pages         = {49-50},
+}
+
+-- Mythlore. Vol. 16, No. 1 (59), Autumn 1989
+-- https://www.jstor.org/stable/i26812047
+
+@article{mythlore:stratyner1989,
+  title         = {_ðe us ðas beagas geaf_ (He who gave us these Rings): Sauron and the Perversion of Anglo-Saxon Ethos},
+  url           = {https://www.jstor.org/stable/26812097},
+  author        = {Stratyner, Leslie},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {1 (59)},
+  year          = {1989},
+  pages         = {5-8},
+}
+
+@article{mythlore:abbott1989a,
+  title         = {Tolkien’s Monsters: Concept and Function in _The Lord of the Rings_ (Part I) The Balrog of Khazad-dum},
+  url           = {https://www.jstor.org/stable/26812101},
+  author        = {Abbott, Joe},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {1 (59)},
+  year          = {1989},
+  pages         = {19-26, 33},
+}
+
+@article{mythlore:treloar1989,
+  title         = {The Middle-earth Epic and the Seven Capital Vices},
+  url           = {https://www.jstor.org/stable/26812105},
+  author        = {Treloar, John L.},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {1 (59)},
+  year          = {1989},
+  pages         = {37-42},
+}
+
+-- Mythlore. Vol. 16, No. 2 (60), Winter 1989
+-- https://www.jstor.org/stable/i26811878
+
+@article{mythlore:startzman1989,
+  title         = {Goldberry and Galadriel: The Quality of Joy},
+  url           = {https://www.jstor.org/stable/26811882},
+  author        = {Startzman, L. Eugene},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {2 (60)},
+  year          = {1989},
+  pages         = {5-13},
+}
+
+@article{mythlore:beachwynnedisante1989,
+  title         = {Three Artistic Versions of "The Death of Glorfindel"},
+  url           = {https://www.jstor.org/stable/26811885},
+  author        = {Beach, Sarah and Wynne, Patrick and DiSante, Paula},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {2 (60)},
+  year          = {1989},
+  pages         = {20-21, 25},
+}
+
+@article{mythlore:obrien1989,
+  title         = {On the Origin of the Name "Hobbit"},
+  url           = {https://www.jstor.org/stable/26811889},
+  author        = {O’Brien, Donald},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {2 (60)},
+  year          = {1989},
+  pages         = {32-38},
+}
+
+@article{mythlore:abbott1989b,
+  title         = {Tolkien’s Monsters: Concept and Function in _The Lord of the Rings_ (Part II) Shelob the Great},
+  url           = {https://www.jstor.org/stable/26811891},
+  author        = {Abbott, Joe},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {2 (60)},
+  year          = {1989},
+  pages         = {40-47},
+}
+
+@article{mythlore:goodknight1989,
+  title         = {Surprising Treasures: _The Treason of Isengard: The History of the Lord of the Rings, Part Two; The History of Middle-earth, Volume VII_ by J.~R.~R. Tolkien, Christopher R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26811893},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {2 (60)},
+  year          = {1989},
+  pages         = {55},
+}
+
+-- Mythlore. Vol. 16, No. 3 (61), Spring 1990
+-- https://www.jstor.org/stable/i26812044
+
+@article{mythlore:flieger1990,
+  title         = {A Question of Time},
+  url           = {https://www.jstor.org/stable/26812978},
+  author        = {Flieger, Verlyn},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {3 (61)},
+  year          = {1990},
+  pages         = {5-8},
+}
+
+@article{mythlore:hyde1990a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812990},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {3 (61)},
+  year          = {1990},
+  pages         = {30-34},
+}
+
+@article{mythlore:abbott1990,
+  title         = {Tolkien’s Monsters: Concept and Function in _The Lord of the Rings_ (Part III) Sauron},
+  url           = {https://www.jstor.org/stable/26813006},
+  author        = {Abbott, Joe},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {3 (61)},
+  year          = {1990},
+  pages         = {51-59},
+}
+
+-- Mythlore. Vol. 16, No. 4 (62), Summer 1990
+-- https://www.jstor.org/stable/i26811960
+
+@article{mythlore:loback1990,
+  title         = {Orc Hosts, Armies and Legions: A Demographic Study},
+  url           = {https://www.jstor.org/stable/26811988},
+  author        = {Loback, Tom},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {4 (62)},
+  year          = {1990},
+  pages         = {10-16, 26},
+}
+
+@article{mythlore:bettridge1990,
+  title         = {Tolkien’s "New" Mythology},
+  url           = {https://www.jstor.org/stable/26811991},
+  author        = {Bettridge, William Edwin},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {4 (62)},
+  year          = {1990},
+  pages         = {27-31},
+}
+
+@article{mythlore:wynne1990a,
+  title         = {Notes Toward a Translation of "Lúthien’s Song"},
+  url           = {https://www.jstor.org/stable/26811995},
+  author        = {Wynne, Patrick},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {4 (62)},
+  year          = {1990},
+  pages         = {37-39},
+}
+
+@article{mythlore:hyde1990b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26811996},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {16},
+  number        = {4 (62)},
+  year          = {1990},
+  pages         = {40-44},
+}
+
+-- Mythlore. Vol. 17, No. 1 (63), Autumn 1990
+-- https://www.jstor.org/stable/i26812119
+
+@article{mythlore:hyde1990c,
+  title         = {Emotion with Dignity: J.~R.~R. Tolkien and Love},
+  url           = {https://www.jstor.org/stable/26812125},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {1 (63)},
+  year          = {1990},
+  pages         = {14-19},
+}
+
+@article{mythlore:ryan1990,
+  title         = {The Mines of Mendip and of Moria},
+  url           = {https://www.jstor.org/stable/26812127},
+  author        = {Ryan, J. S.},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {1 (63)},
+  year          = {1990},
+  pages         = {25-27, 64},
+}
+
+-- Mythlore. Vol. 17, No. 2 (64), Winter 1990
+-- https://www.jstor.org/stable/i26812814
+
+@article{mythlore:wynne1990b,
+  title         = {"Fëanor Fronts Fingolfin": Artistic Visions of Four Artists},
+  url           = {https://www.jstor.org/stable/26812844},
+  author        = {Wynne, Patrick and Loback, Tom and DiSante, Paula and Beach, Sarah},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {2 (64)},
+  year          = {1990},
+  pages         = {20-21},
+}
+
+@article{mythlore:broadwell1990,
+  title         = {_Essë_ and _Narn_: Name, Identity, and Narrative in the Tale of Túrin Turambar},
+  url           = {https://www.jstor.org/stable/26812847},
+  author        = {Broadwell, Elizabeth},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {2 (64)},
+  year          = {1990},
+  pages         = {34-44},
+}
+
+@article{mythlore:hyde1990d,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812849},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {2 (64)},
+  year          = {1990},
+  pages         = {45-49},
+}
+
+@article{mythlore:goodknight1990,
+  title         = {The Gathering Clouds: _The War of the Ring: The History of The Lord of the Rings, Part Three; The History of Middle-earth, Volume VIII_ by J.~R.~R. Tolkien, Christopher Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26812851},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {2 (64)},
+  year          = {1990},
+  pages         = {51-52},
+}
+
+@article{mythlore:patterson1990,
+  title         = {Farewell to Middle-earth: _Bilbo’s Last Song_ by J.~R.~R. Tolkien, Pauline Baynes (review)},
+  url           = {https://www.jstor.org/stable/26812852},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {2 (64)},
+  year          = {1990},
+  pages         = {51-52},
+}
+
+@article{mythlore:havard1990,
+  title         = {Professor J.~R.~R. Tolkien: A Personal Memoir},
+  url           = {https://www.jstor.org/stable/26812862},
+  author        = {Havard, R. E.},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {2 (64)},
+  year          = {1990},
+  pages         = {61-63},
+}
+
+-- Mythlore. Vol. 17, No. 3 (65), Spring 1991
+-- https://www.jstor.org/stable/i26812573
+
+@article{mythlore:hostetter1991,
+  title         = {Over Middle-earth Sent Unto Men: On the Philological Origins of Tolkien’s Eärendel Myth},
+  url           = {https://www.jstor.org/stable/26812595},
+  author        = {Hostetter, Carl F.},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {3 (65)},
+  year          = {1991},
+  pages         = {5-10},
+}
+
+@article{mythlore:gilsonwynne1991,
+  title         = {The Elves at Koivienéni: A New Quenya Sentence},
+  url           = {https://www.jstor.org/stable/26812598},
+  author        = {Gilson, Christopher and Wynne, Patrick},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {3 (65)},
+  year          = {1991},
+  pages         = {23-30},
+}
+
+@article{mythlore:hyde1991a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812600},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {3 (65)},
+  year          = {1991},
+  pages         = {37-38},
+}
+
+@article{mythlore:hyde1991b,
+  title         = {A Comprehensive Index of Proper Names and Phrases in _The Hobbit_},
+  url           = {https://www.jstor.org/stable/26812601},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {17},
+  number        = {3 (65)},
+  year          = {1991},
+  pages         = {39-42},
+}
+
+-- Mythlore. Vol. 18, No. 1 (67), Autumn 1991
+-- https://www.jstor.org/stable/i26812455
+
+@article{mythlore:langford1991,
+  title         = {The Scouring of the Shire as a Hobbit Coming-of-Age},
+  url           = {https://www.jstor.org/stable/26812481},
+  author        = {Langford, Jonathon D.},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {1 (67)},
+  year          = {1991},
+  pages         = {4-9},
+}
+
+@article{mythlore:arthur1991,
+  title         = {Above All Shadows Rides the Sun: Gollum as Hero},
+  url           = {https://www.jstor.org/stable/26812484},
+  author        = {Arthur, Elizabeth},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {1 (67)},
+  year          = {1991},
+  pages         = {19-27},
+}
+
+@article{mythlore:beach1991,
+  title         = {Fire and Ice: The Traditional Heroine in _The Simarillion_},
+  url           = {https://www.jstor.org/stable/26812488},
+  author        = {Beach, Sarah},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {1 (67)},
+  year          = {1991},
+  pages         = {37-41},
+}
+
+@article{mythlore:seeman1991,
+  title         = {Tolkien and Campbell Compared},
+  url           = {https://www.jstor.org/stable/26812490},
+  author        = {Seeman, Chris},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {1 (67)},
+  year          = {1991},
+  pages         = {43-48},
+}
+
+-- Mythlore. Vol. 18, No. 2 (68), Spring 1992
+-- https://www.jstor.org/stable/i26812661
+
+@article{mythlore:greenman1992,
+  title         = {Aeneidic and Odyssean Patterns of Escape and Return: in Tolkien’s _The Fall of Gondolin_ and _The Return of the King_},
+  url           = {https://www.jstor.org/stable/26812686},
+  author        = {Greenman, David},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {2 (68)},
+  year          = {1992},
+  pages         = {4-9},
+}
+
+@article{mythlore:hyde1992a,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26812691},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {2 (68)},
+  year          = {1992},
+  pages         = {23-27},
+}
+
+-- Mythlore. Vol. 18, No. 3 (69), Summer 1992, Special J .R. R. Tolkien Centenary Issue
+-- https://www.jstor.org/stable/i26812453
+
+@article{mythlore:manganiello1992,
+  title         = {The Neverending Story: Textual Happiness in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26813050},
+  author        = {Manganiello, Dominic},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {3 (69)},
+  year          = {1992},
+  pages         = {5-14},
+}
+
+@article{mythlore:graff1992,
+  title         = {The Three Faces of Faërie in Tolkien’s Shorter Fiction: Niggle, Smith and Giles},
+  url           = {https://www.jstor.org/stable/26813051},
+  author        = {Graff, Eric S.},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {3 (69)},
+  year          = {1992},
+  pages         = {15-19},
+}
+
+@article{mythlore:hyde1992b,
+  title         = {_Quenti Lambardillion_: A Column on Middle-earth Linguistics},
+  url           = {https://www.jstor.org/stable/26813052},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {3 (69)},
+  year          = {1992},
+  pages         = {20-26},
+}
+
+@article{mythlore:mathews1992,
+  title         = {The Edges of Reality: in Tolkien’s Tale of Aldarion and Erendis},
+  url           = {https://www.jstor.org/stable/26813054},
+  author        = {Mathews, Richard},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {3 (69)},
+  year          = {1992},
+  pages         = {27-31},
+}
+
+@article{mythlore:hyde1992c,
+  title         = {Literary and Linguistic Genius: _Sauron Defeated_ by J.~R.~R. Tolkien, Christopher R. Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26813060},
+  author        = {Hyde, Paul Nolan},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {3 (69)},
+  year          = {1992},
+  pages         = {55},
+}
+
+@article{mythlore:goodknight1992a,
+  title         = {The Ring Goes Grey: _The Lord of the Rings_ by J.~R.~R. Tolkien, Alan Lee (review)},
+  url           = {https://www.jstor.org/stable/26813061},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {3 (69)},
+  year          = {1992},
+  pages         = {55-57},
+}
+
+@article{mythlore:patterson1992,
+  title         = {Wolves and Snakes: _J.~R.~R. Tolkien, Master of Fantasy_ by David R. Collins (review)},
+  url           = {https://www.jstor.org/stable/26813063},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {3 (69)},
+  year          = {1992},
+  pages         = {58},
+}
+
+@article{mythlore:goodknight1992b,
+  title         = {J.~R.~R. Tolkien in Translation},
+  url           = {https://www.jstor.org/stable/26813065},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {18},
+  number        = {3 (69)},
+  year          = {1992},
+  pages         = {61-69},
+}
+
+-- Mythlore. Vol. 18, No. 4 (70), Autumn 1992
+-- https://www.jstor.org/stable/i26812613
+
+@article{mythlore:stoddard1992,
+  title         = {Law and Institutions in the Shire},
+  url           = {https://www.jstor.org/stable/26812640},
+  author        = {Stoddard, William H.},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {4 (70)},
+  year          = {1992},
+  pages         = {4-8},
+}
+
+@article{mythlore:goodknight1992c,
+  title         = {Tolkien Treasure Old and New: _J.~R.~R. Tolkien: Life and Legend_ by Judith Priestman (review)},
+  url           = {https://www.jstor.org/stable/26812652},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {4 (70)},
+  year          = {1992},
+  pages         = {45-46},
+}
+
+@article{mythlore:vanhecke1992,
+  title         = {Tolkien in Dutch: A Study of the Reception of Tolkien’s Work in Belgium and the Netherlands},
+  url           = {https://www.jstor.org/stable/26812658},
+  author        = {Vanhecke, Johan},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {4 (70)},
+  year          = {1992},
+  pages         = {53-60},
+}
+
+-- Mythlore. Vol. 19, No. 1 (71), Winter 1993
+-- https://www.jstor.org/stable/i26812502
+
+@article{mythlore:rawls1993,
+  title         = {The Verse of J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26812550},
+  author        = {Rawls, Melanie A.},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {1 (71)},
+  year          = {1993},
+  pages         = {4-8},
+}
+
+@article{mythlore:sarjeant1993,
+  title         = {Where Did The Dwarves Come From?},
+  url           = {https://www.jstor.org/stable/26812562},
+  author        = {Sarjeant, William A. S.},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {1 (71)},
+  year          = {1993},
+  pages         = {43, 64},
+}
+
+@article{mythlore:goodknight1993a,
+  title         = {Unexpected Centenary Surprise: _J.~R.~R. Tolkien, Architect of Middle-earth_ by Daniel Grotta, Brothers Hildebrant (review)},
+  url           = {https://www.jstor.org/stable/26812569},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {1 (71)},
+  year          = {1993},
+  pages         = {54-55},
+}
+
+-- Mythlore. Vol. 19, No. 2 (72), Spring 1993
+-- https://www.jstor.org/stable/i26812708
+
+@article{mythlore:mccomas1993a,
+  title         = {Negating and Affirming Spirit Through Language: The Integration of Character, Magic, and Story in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26812733},
+  author        = {McComas, Alan},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {2 (72)},
+  year          = {1993},
+  pages         = {4-15},
+}
+
+@article{mythlore:zimmer1993,
+  title         = {Another Opinion of "The Verse of J.~R.~R. Tolkien"},
+  url           = {https://www.jstor.org/stable/26812735},
+  author        = {Zimmer, Paul Edwin},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {2 (72)},
+  year          = {1993},
+  pages         = {16-23},
+}
+
+@article{mythlore:reynolds1993,
+  title         = {Funeral Customs in Tolkien’s Fiction},
+  url           = {https://www.jstor.org/stable/26812745},
+  author        = {Reynolds, Patricia},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {2 (72)},
+  year          = {1993},
+  pages         = {45-53},
+}
+
+-- Mythlore. Vol. 19, No. 3 (73), Summer 1993
+-- https://www.jstor.org/stable/i26812837
+
+@article{mythlore:mccomas1993b,
+  title         = {Negating and Affirming Spirit Through Language: The Integration of Character, Magic, and Story in _The Lord of the Rings_: Part II"},
+  url           = {https://www.jstor.org/stable/26812879},
+  author        = {McComas, Alan},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {3 (73)},
+  year          = {1993},
+  pages         = {40-49},
+}
+
+@article{mythlore:goodknight1993b,
+  title         = {Eluding the Conventional. _Tolkien: A Critical Assessment_ by Brian Rosebury (review)},
+  url           = {https://www.jstor.org/stable/26812880},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {3 (73)},
+  year          = {1993},
+  pages         = {50-51},
+}
+
+@article{mythlore:goodknight1993c,
+  title         = {An Excellent Road. _The Road to Middle-earth_ (Second Edition) by T.~A. Shippey (review)},
+  url           = {https://www.jstor.org/stable/26812881},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {3 (73)},
+  year          = {1993},
+  pages         = {50-51},
+}
+
+@article{mythlore:goodknight1993d,
+  title         = {Essential Reference. _J.~R.~R. Tolkien: A Descriptive Bibliography_ by Wayne Hammond, Douglas Anderson (review)},
+  url           = {https://www.jstor.org/stable/26812882},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {3 (73)},
+  year          = {1993},
+  pages         = {50-51},
+}
+
+-- Mythlore. Vol. 19, No. 4 (74), Autumn 1993
+-- https://www.jstor.org/stable/i26812591
+
+@article{mythlore:hood1993,
+  title         = {Nature and Technology: Angelic and Sacrificial Strategies in Tolkien’s _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26812617},
+  author        = {Hood, Gyneth},
+  journal       = {Mythlore},
+  volume        = {19},
+  number        = {4 (74)},
+  year          = {1993},
+  pages         = {6-12},
+}
+
+-- Mythlore. Vol. 20, No. 1 (75), Winter 1994
+-- https://www.jstor.org/stable/i26812772
+
+@article{mythlore:thompson1994,
+  title         = {Tolkien’s Word-Hord _Onlēac_},
+  url           = {https://www.jstor.org/stable/26812823},
+  author        = {Thompson, Ricky L.},
+  journal       = {Mythlore},
+  volume        = {20},
+  number        = {1 (75)},
+  year          = {1994},
+  pages         = {22-40},
+}
+-- Mythlore. Vol. 20, No. 2 (76), Spring 1994
+-- https://www.jstor.org/stable/i26812523
+
+@article{mythlore:juhren1994,
+  title         = {The Ecology of Middle-Earth},
+  url           = {https://www.jstor.org/stable/26812527},
+  author        = {Juhren, Marcella},
+  journal       = {Mythlore},
+  volume        = {20},
+  number        = {2 (76)},
+  year          = {1994},
+  pages         = {5-8},
+}
+
+@article{mythlore:juhren1994app,
+  title         = {Plants of Principal Phyto-Geographic Regions of Middle-earth},
+  url           = {https://www.jstor.org/stable/26812528},
+  author        = {Juhren, Marcella},
+  journal       = {Mythlore},
+  volume        = {20},
+  number        = {2 (76)},
+  year          = {1994},
+  pages         = {8-9},
+}
+
+% Tolkien Sings for the Lilliputians: Poems by J.R.R. Tolkien by J.R.R. Tolkien (p. 35)
+% Reviewed by: Glen GoodKnight
+% Too small to still be of interest.
+%https://www.jstor.org/stable/26812538
+
+@article{mythlore:goodknight1994,
+  title         = {A Thing Wholly Different: _Morgoth’s Ring: the Later Silmarillion, Part One, The Legend of Aman. The History of Middle-earth Volume X_ by J.~R.~R. Tolkien, Christopher Tolkien (review)},
+  url           = {https://www.jstor.org/stable/26812540},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {20},
+  number        = {2 (76)},
+  year          = {1994},
+  pages         = {35-38},
+}
+
+% Major Minors: Poems and Stories by J.R.R. Tolkien, Pauline Baynes (p. 39)
+% Reviewed by: Glen GoodKnight
+% Too small to still be of interest.
+% https://www.jstor.org/stable/26812543
+
+-- Mythlore. Vol. 20, No. 3 (77), Summer 1994
+-- https://www.jstor.org/stable/i26812728
+
+% This issue does have any articles.
+% (At least none indexed in JSTOR).
+
+-- Mythlore. Vol. 20, No. 4 (78), Winter 1995
+-- https://www.jstor.org/stable/i26812478
+
+@article{mythlore:keene1995,
+  title         = {The Restoration of Language in Middle-earth},
+  url           = {https://www.jstor.org/stable/26812506},
+  author        = {Keene, Louise E.},
+  journal       = {Mythlore},
+  volume        = {20},
+  number        = {4 (78)},
+  year          = {1995},
+  pages         = {6-13},
+}
+
+@article{mythlore:gorman1995,
+  title         = {J.~R.~R. Tolkien’s "Leaf by Niggle": Word Pairs and Paradoxes},
+  url           = {https://www.jstor.org/stable/26812515},
+  author        = {Gorman, Anita G.},
+  journal       = {Mythlore},
+  volume        = {20},
+  number        = {4 (78)},
+  year          = {1995},
+  pages         = {52-55},
+}
+
+-- Mythlore. Vol. 21, No. 1 (79), Summer 1995
+-- https://www.jstor.org/stable/i26812637
+
+@article{mythlore:houghton1995,
+  title         = {Augustine and the _Ainulindale_},
+  url           = {https://www.jstor.org/stable/26812664},
+  author        = {Houghton, John Wm.},
+  journal       = {Mythlore},
+  volume        = {21},
+  number        = {1 (79)},
+  year          = {1995},
+  pages         = {4-8},
+}
+
+@article{mythlore:smith1995,
+  title         = {Duzen and Ihrzen in the German Translation of _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26812669},
+  author        = {Smith, Arden R.},
+  journal       = {Mythlore},
+  volume        = {21},
+  number        = {1 (79)},
+  year          = {1995},
+  pages         = {33-34, 36-40},
+}
+
+-- Mythlore. Vol. 21, No. 2 (80), Winter 1996
+-- https://www.jstor.org/stable/i40240361
+
+% See Mallorn, issue 33, 1995 = Same content, indexed there.
+
+-- Mythlore. Vol. 21, No. 3 (81), Summer 1996
+-- https://www.jstor.org/stable/i26812547
+
+@article{mythlore:fenwick1996,
+  title         = {Breastplates of Silk: Homeric Women in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26812579},
+  author        = {Fenwick, Mac},
+  journal       = {Mythlore},
+  volume        = {21},
+  number        = {3 (81)},
+  year          = {1996},
+  pages         = {17-23, 50},
+}
+
+@article{mythlore:goodknight1996,
+  title         = {Superb Milestone. _J.~R.~R. Tolkien: Artist & Illustrator_ by Wayne G. Hammond, Christina Scull (review)},
+  url           = {https://www.jstor.org/stable/26812584},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {21},
+  number        = {3 (81)},
+  year          = {1996},
+  pages         = {51-52},
+}
+
+-- Mythlore. Vol. 21, No. 4 (82), Winter 1997
+-- https://www.jstor.org/stable/i26812730
+
+@article{mythlore:sterling1997,
+  title         = {"The Gift of Death": Tolkien’s Philosophy of Mortality},
+  url           = {https://www.jstor.org/stable/26812755},
+  author        = {Sterling, Grant C.},
+  journal       = {Mythlore},
+  volume        = {21},
+  number        = {4 (82)},
+  year          = {1997},
+  pages         = {16-18, 38},
+}
+
+@article{mythlore:sander1997,
+  title         = {Mr. Bliss and Mr. Toad: Hazardous Driving in J.~R.~R. Tolkien’s _Mr. Bliss_ & Kenneth Grahame’s _The Wind in the Willows_},
+  url           = {https://www.jstor.org/stable/26812758},
+  author        = {Sander, David},
+  journal       = {Mythlore},
+  volume        = {21},
+  number        = {4 (82)},
+  year          = {1997},
+  pages         = {36-38},
+}
+
+@article{mythlore:patterson1997a,
+  title         = {Sensuous Precision. _Tolkien — A Critical Assessment_ by Brian Rosebury},
+  url           = {https://www.jstor.org/stable/26812764},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {21},
+  number        = {4 (82)},
+  year          = {1997},
+  pages         = {57-58},
+}
+
+-- Mythlore. Vol. 22, No. 1 (83), Autumn 1997
+-- https://www.jstor.org/stable/i26812683
+
+@article{mythlore:sandner1997,
+  title         = {The Fantastic Sublime: Tolkien’s "On Fairy-Stories" and the Romantic Sublime},
+  url           = {https://www.jstor.org/stable/26813026},
+  author        = {Sandner, David},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {1 (83)},
+  year          = {1997},
+  pages         = {4-7},
+}
+
+@article{mythlore:garciadelapuerta1997,
+  title         = {J.~R.~R. Tolkien’s Use Of Nature: Correlations with Galicians’ Sense of Nature},
+  url           = {https://www.jstor.org/stable/26813029},
+  author        = {García de La Puerta, Marta},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {1 (83)},
+  year          = {1997},
+  pages         = {22-25},
+}
+
+@article{mythlore:thomson1997,
+  title         = {Annotated Checklists of Early Reviews of Books by J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26813035},
+  author        = {Thompson, George H.},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {1 (83)},
+  year          = {1997},
+  pages         = {58-59},
+}
+
+@article{mythlore:patterson1997b,
+  title         = {Designer and Artist. _J.~R.~R. Tolkien: Artist and Illustrator_ by Wayne G. Hammond, Christina Scull (review)},
+  url           = {https://www.jstor.org/stable/26813037},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {1 (83)},
+  year          = {1997},
+  pages         = {60-61},
+}
+
+-- Mythlore. Vol. 22, No. 2 (84), Summer 1998
+-- https://www.jstor.org/stable/i26812454
+
+% This issue does not seem to have any Tolkien-related articles.
+% (At least none indexed in JSTOR).
+
+-- Mythlore. Vol. 22, No. 3 (85), Winter 1999
+-- https://www.jstor.org/stable/i40240359
+
+@article{mythlore:flieger1999,
+  title         = {Fantasy and Reality: J.~R.~R. Tolkien’s World and the Fairy-Story Essay},
+  url           = {https://www.jstor.org/stable/45482865},
+  author        = {Flieger, Verlyn},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {3 (85)},
+  year          = {1999},
+  pages         = {4-13},
+}
+
+@article{mythlore:hammondscull1999,
+  title         = {J.~R.~R. Tolkien: The Achievement of His Literary Life},
+  url           = {https://www.jstor.org/stable/45482867},
+  author        = {Hammond, Wayne G. and Scull, Christina},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {3 (85)},
+  year          = {1999},
+  pages         = {27-37},
+}
+
+-- Mythlore. Vol. 22, No. 4 (86), Spring 2000
+-- https://www.jstor.org/stable/i26814353
+
+T@article{mythlore:bratman2000,
+  title         = {Top Ten Rejected Plot Twists from _The Lord of the Rings_: A Textual Excursion into the "History of the _The Lord of the Rings_"},
+  url           = {https://www.jstor.org/stable/26814530},
+  author        = {Bratman, David},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {4 (86)},
+  year          = {2000},
+  pages         = {13-37},
+}
+
+@article{mythlore:adderley2000,
+  title         = {Meeting Morgan le Fay: J.~R.~R. Tolkien’s Theory of Subcreation and the Secondary World of _Sir Gawain and the Green Knight_},
+  url           = {https://www.jstor.org/stable/26814532},
+  author        = {Adderley, C. M.},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {4 (86)},
+  year          = {2000},
+  pages         = {48-58},
+}
+
+@article{mythlore:himes2000,
+  title         = {What J.~R.~R. Tolkien Really Did with the Sampo?},
+  url           = {https://www.jstor.org/stable/26814535},
+  author        = {Himes, Jonathan B.},
+  journal       = {Mythlore},
+  volume        = {22},
+  number        = {4 (86)},
+  year          = {2000},
+  pages         = {69-85},
+}
+
+-- Mythlore. Vol. 23, No. 1 (87), Summer/Fall 2000
+-- https://www.jstor.org/stable/i26814245
+
+@article{mythlore:flieger2000,
+  title         = {J.~R.~R. Tolkien and the Matter of Britain},
+  url           = {https://www.jstor.org/stable/26814251},
+  author        = {Flieger, Verlyn},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {1 (87)},
+  year          = {2000},
+  pages         = {47-58},
+}
+
+@article{mythlore:patterson2000,
+  title         = {_Roverandom_ by J.~R.~R. Tolkien, Christina Scull, Wayne G. Hammond (review)},
+  url           = {https://www.jstor.org/stable/26814255},
+  author        = {Patterson, Nancy-Lou},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {1 (87)},
+  year          = {2000},
+  pages         = {74-75},
+}
+
+-- Mythlore. Vol. 23, No. 2 (88), Spring 2001
+-- https://www.jstor.org/stable/i26814271
+
+% This issue does not seem to have any Tolkien-related articles.
+% (At least none indexed in JSTOR).
+
+-- Mythlore. Vol. 23, No. 3 (89), Summer 2001
+-- https://www.jstor.org/stable/i26814232
+
+@article{mythlore:crowe2001,
+  title         = {Making and Unmaking in Middle-earth and Elsewhere},
+  url           = {https://www.jstor.org/stable/26814239},
+  author        = {Crowe, Edith L.},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {3 (89)},
+  year          = {2001},
+  pages         = {56-69},
+}
+
+@article{mythlore:timmons2001,
+  title         = {Hobbit Sesx and Sensuality in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26814240},
+  author        = {Timmons, Daniel},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {3 (89)},
+  year          = {2001},
+  pages         = {70-79},
+}
+
+-- Mythlore. Vol. 23, No. 4 (90), Fall-Winter 2002
+-- https://www.jstor.org/stable/i26814260
+
+@article{mythlore:croft2002,
+  title         = {The Great War and Tolkien’s Memory: An Examination of World War I Themes in _The Hobbit_ and _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26814263},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {4 (90)},
+  year          = {2002},
+  pages         = {4-21},
+}
+
+@article{mythlore:lakowski2002,
+  title         = {Types of Heroism in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26814264},
+  author        = {Lakowski, Romuald Ian},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {4 (90)},
+  year          = {2002},
+  pages         = {22-35},
+}
+
+@article{mythlore:upstone2002,
+  title         = {Applicability and Truth in _The Hobbit_, _The Lord of the Rings_, and _The Silmarillion_: Readers, Fantasy, and Canonicity},
+  url           = {https://www.jstor.org/stable/26814266},
+  author        = {Upstone, Sara},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {4 (90)},
+  year          = {2002},
+  pages         = {50-66},
+}
+
+@article{mythlore:tompkins2002,
+  title         = {"The Homecoming of Beorhtnoth Beorhthelm’s Son": Tolkien as a Modern Anglo-Saxon},
+  url           = {https://www.jstor.org/stable/26814267},
+  author        = {Tompkins, J. Case},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {4 (90)},
+  year          = {2002},
+  pages         = {67-74},
+}
+
+@article{mythlore:weidner2002,
+  title         = {Middle-earth: The Real World of J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26814268},
+  author        = {Weidner, Brian N.},
+  journal       = {Mythlore},
+  volume        = {23},
+  number        = {4 (90)},
+  year          = {2002},
+  pages         = {75-84},
+}
+
+-- Mythlore. Vol. 24, No. 1 (91), Summer 2003
+-- https://www.jstor.org/stable/i26814222
+
+% This issue does not seem to have any Tolkien-related articles.
+% (At least none indexed in JSTOR).
+
+-- Mythlore. Vol. 24, No. 2 (92), Summer/Fall 2004
+-- https://www.jstor.org/stable/i40240897
+
+@article{mythlore:hannon2004,
+  title         = {_The Lord of the Rings_ as Elegy},
+  url           = {https://www.jstor.org/stable/45492652},
+  author        = {Hannon, Patrice},
+  journal       = {Mythlore},
+  volume        = {24},
+  number        = {2 (92)},
+  year          = {2004},
+  pages         = {36-42},
+}
+
+@article{mythlore:croft2004,
+  title         = {"The Young Perish and the Old Linger, Withering": J.~R.~R. Tolkien on World War II},
+  url           = {https://www.jstor.org/stable/45492654},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {24},
+  number        = {2 (92)},
+  year          = {2004},
+  pages         = {58-71},
+}
+
+-- Mythlore. Vol. 24, No. 3/4 (93/94), Winter/Spring 2006
+-- https://www.jstor.org/stable/i26814259
+
+@article{mythlore:kightley2006,
+  title         = {Heorot or Meduseld?: Tolkien’s Use of _Beowulf_ in "The King of the Golden Hall"},
+  url           = {https://www.jstor.org/stable/26814548},
+  author        = {Kightley, Michael R.},
+  journal       = {Mythlore},
+  volume        = {24},
+  number        = {3/4 (93/94)},
+  year          = {2006},
+  pages         = {119-134},
+}
+
+@article{mythlore:zemmour2006,
+  title         = {Tolkien in the Land of Arthur: The Old Forest Episode from _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26814549},
+  author        = {Zemmour, Corinne},
+  journal       = {Mythlore},
+  volume        = {24},
+  number        = {3/4 (93/94)},
+  year          = {2006},
+  pages         = {135-163},
+}
+
+@article{mythlore:sturgis2006,
+  title         = {Reimagining Rose: Portrayals of Tolkien’s Rosie Cotton in Twenty-First Century Fan Fiction},
+  url           = {https://www.jstor.org/stable/26814550},
+  author        = {Sturgis, Amy H.},
+  journal       = {Mythlore},
+  volume        = {24},
+  number        = {3/4 (93/94)},
+  year          = {2006},
+  pages         = {165-187},
+}
+
+-- Mythlore. Vol. 25, No. 1/2 (95/96), Fall/Winter 2006
+-- https://www.jstor.org/stable/i40240898
+
+@article{mythlore:whettermcdonald2006,
+  title         = {"In the Hilt is Fame": Resonances of Medieval Swords and Sword-lore in J.~R.~R. Tolkien’s _The Hobbit_ and _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/45492658},
+  author        = {Whetter, K. S. and McDonald, R. Andrew},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {5-28},
+}
+
+@article{mythlore:hall2006,
+  title         = {The Theory and Practice of Alliterative Verse in the Work of J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/45492660},
+  author        = {Hall, Mark F.},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {41-52},
+}
+
+@article{mythlore:bossert2006,
+  title         = {"Surely You Don’t Disbelieve": Tolkien and Pius X: Anti-Modernism in Middle-earth},
+  url           = {https://www.jstor.org/stable/45492661},
+  author        = {Bossert, A. R.},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {53-76},
+}
+
+@article{mythlore:livingston2006,
+  title         = {The Shell-shocked Hobbit: The First World War and Tolkien’s Trauma of the Ring},
+  url           = {https://www.jstor.org/stable/45492662},
+  author        = {Livingston, Michael},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {77-92},
+}
+
+@article{mythlore:amison2006,
+  title         = {An Unexpected Guest},
+  url           = {https://www.jstor.org/stable/45492665},
+  author        = {Amison, Anne},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {127-136},
+}
+
+@article{mythlore:steele2006,
+  title         = {Dreaming of Dragons: Tolkien’s Impact on Heaney’s _Beowulf_},
+  url           = {https://www.jstor.org/stable/45492666},
+  author        = {Steele, Felicia Jean},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {137-146},
+}
+
+@article{mythlore:fife2006,
+  title         = {Wise Warriors in Tolkien, Lewis, and Rowling},
+  url           = {https://www.jstor.org/stable/45492667},
+  author        = {Fife, Ernelle},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {147-162},
+}
+
+@article{mythlore:brown2006,
+  title         = {From Isolation to Community: Frodo’s Incomplete Personal Quest in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/45492668},
+  author        = {Brown, Devin},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {163-173},
+}
+
+@article{mythlore:treschowduckworth2006,
+  title         = {Bombadil’s Role in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/45492669},
+  author        = {Treschow, Michael and Duckworth, Mark},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {1/2 (95/96)},
+  year          = {2006},
+  pages         = {175-196},
+}
+
+-- Mythlore. Vol. 25, No. 3/4 (97/98), Spring/Summer 2007
+-- https://www.jstor.org/stable/i26814244
+
+@article{mythlore:donnelly2007,
+  title         = {Feudal Values, Vassalage, and Fealty in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26814604},
+  author        = {Donnelly, Colleen},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {17-27},
+}
+
+@article{mythlore:fredrick2007,
+  title         = {Battling the Woman Warrior: Females and Combat in Tolkien and Lewis},
+  url           = {https://www.jstor.org/stable/26814605},
+  author        = {Fredrick, Candice and McBride, Sam},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {29-42},
+}
+
+@article{mythlore:hatcher2007,
+  title        = {Finding Woman’s Role in _The Lord of the Rings_},
+  url          = {https://www.jstor.org/stable/26814606},
+  author       = {Hatcher, Melissa McCrory},
+  journal      = {Mythlore},
+  volume       = {25},
+  number       = {3/4 (97/98)},
+  year         = {2007},
+  pages        = {43-54},
+}
+
+@article{mythlore:hall2007,
+  title         = {Through a Dark Lens: Jackson’s _Lord of the Rings_ as Abject Horror},
+  url           = {https://www.jstor.org/stable/26814607},
+  author        = {Hall, R.~D.},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {55-59},
+}
+
+@article{mythlore:harl2007,
+  title         = {The Monstrosity of the Gaze: Critical Problems with a Film Adaptation of _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26814608},
+  author        = {Harl, Allison},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {61-69},
+}
+
+@article{mythlore:carter2007,
+  title         = {Galadriel and Morgan le Fey: Tolkien’s Redemption of the Lady of the Lacuna},
+  url           = {https://www.jstor.org/stable/26814609},
+  author        = {Carter, Susan},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {71-89},
+}
+
+@article{mythlore:lakowski2007,
+  title         = {The Fall and Repentance of Galadriel},
+  url           = {https://www.jstor.org/stable/26814610},
+  author        = {Lakowski, Romuald Ian},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {91-104},
+}
+
+@article{mythlore:peretti2007,
+  title         = {The Ogre Blinded and _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26814613},
+  author        = {Peretti, Daniel},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {133-143},
+}
+
+@article{mythlore:lewis2007,
+  title         = {Beorn and Tom Bombadil: A Tale of Two Heroes},
+  url           = {https://www.jstor.org/stable/26814614},
+  author        = {Lewis, Paul W.},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {145-160},
+}
+
+@article{mythlore:oberhelman2007,
+  title         = {_The J.~R.~R. Tolkien Companion and Guide_ by Christina Scull, Wayne G. Hammond (review)},
+  url           = {https://www.jstor.org/stable/26814616},
+  author        = {Oberhelman, David D.},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {183-185},
+}
+
+@article{mythlore:hutton2007,
+  title         = {_The Lord of the Rings and Philosophy: One Book to Rule Them All_ by Gregory Bassham, Eric Bronson (review)},
+  url           = {https://www.jstor.org/stable/26814617},
+  author        = {Hutton, Clark},
+  journal       = {Mythlore},
+  volume        = {25},
+  number        = {3/4 (97/98)},
+  year          = {2007},
+  pages         = {185-186},
+}
+
+-- Mythlore. Vol. 26, No. 1/2 (99/100), Fall/Winter 2007
+-- https://www.jstor.org/stable/i40240899
+
+@article{mythlore:huttar2007,
+  title         = {"Deep Lies the Sea-Longing": Inklings of Home},
+  url           = {https://www.jstor.org/stable/45492674},
+  author        = {Huttar, Charles A.},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {5-27},
+}
+
+@article{mythlore:glyer2007,
+  title         = {The Centre of the Inklings: Lewis? Williams? Barfield? Tolkien?},
+  url           = {https://www.jstor.org/stable/45492675},
+  author        = {Glyer, Diana Pavlac},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {29-39},
+}
+
+@article{mythlore:nikakis2007,
+  title         = {Sacral Kingship: Aragorn as the Rightful and Sacrificial king in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/45492678},
+  author        = {Nikakis, Karen Simpson},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {83-90},
+}
+
+@article{mythlore:sabo2007,
+  title         = {Archaeology and the Sense of History in J.~R.~R. Tolkien’s Middle-earth},
+  url           = {https://www.jstor.org/stable/45492679},
+  author        = {Sabo, Deborah},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {91-112},
+}
+
+@article{mythlore:birns2007,
+  title         = {The Enigma of Radagast: Revision, Melodrama, and Depth},
+  url           = {https://www.jstor.org/stable/45492680},
+  author        = {Birns, Nicholas},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {113-126},
+}
+
+@article{mythlore:berman2007,
+  title         = {Tolkien as a Child of _The Green Fairy Book_},
+  url           = {https://www.jstor.org/stable/45492681},
+  author        = {Berman, Ruth},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {127-135},
+}
+
+@article{mythlore:head2007,
+  title         = {Imitative Desire in Tolkien’s Mythology: A Girardian Perspective},
+  url           = {https://www.jstor.org/stable/45492682},
+  author        = {Head, Hayden},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {137-148},
+}
+
+@article{mythlore:bruce2007,
+  title         = {Maldon and Moria: On Byrhtnoth, Gandalf, and Heroism in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/45492683},
+  author        = {Bruce, Alexander M.},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {149-159},
+}
+
+@article{mythlore:smith2007,
+  title         = {At Home and Abroad: Eowyn’s Two-Fold Figuring as War Bride in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/45492684},
+  author        = {Smith, Melissa},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {161-172},
+}
+
+@article{mythlore:lazo2007,
+  title         = {_The Company They Keep: C.~S. Lewis and J.~R.~R. Tolkien as Writers in Community_ by Diana Pavlac Glyer (review)},
+  url           = {https://www.jstor.org/stable/45492689},
+  author        = {Lazo, Andrew},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {206-208},
+}
+
+@article{mythlore:fisher2007,
+  title         = {_Roots and Branches: Selected Papers on Tolkien_ by Tom Shippey (review)},
+  url           = {https://www.jstor.org/stable/45492690},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {1/2 (99/100)},
+  year          = {2007},
+  pages         = {209-212},
+}
+
+-- Mythlore. Vol. 26, No. 3/4 (101/102), Spring/Summer 2008
+-- https://www.jstor.org/stable/i26814578
+
+@article{mythlore:hawkins2008a,
+  title         = {Tolkien’s Linguistic Application of the Seventh Deadly Sin: Lust},
+  url           = {https://www.jstor.org/stable/26814583},
+  author        = {Hawkins, Emma B.},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {3/4 (101/102)},
+  year          = {2008},
+  pages         = {29-40},
+}
+
+@article{mythlore:agan2008,
+  title         = {Song as Mythic Conduit in _The Fellowship of the Ring_},
+  url           = {https://www.jstor.org/stable/26814584},
+  author        = {Agan, Cami D.},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {3/4 (101/102)},
+  year          = {2008},
+  pages         = {41-63},
+}
+
+@article{mythlore:nelson2008,
+  title         = {"The Homecoming of Beorhtnoth Beorhthelm’s Son": J.~R.~R. Tolkien’s Sequel to "The Battle of Maldon"},
+  url           = {https://www.jstor.org/stable/26814585},
+  author        = {Nelson, Marie},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {3/4 (101/102)},
+  year          = {2008},
+  pages         = {65-87},
+}
+
+@article{mythlore:long2008,
+  title         = {Two Views of Faerie in "Smith of Wootton Major": Nokes and his Cake, Smith and his Star},
+  url           = {https://www.jstor.org/stable/26814586},
+  author        = {Long, Josh B.},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {3/4 (101/102)},
+  year          = {2008},
+  pages         = {89-100},
+}
+
+@article{mythlore:vincent2008,
+  title         = {Putting Away Childish Things: Incidents of "Recovery" in Tolkien and Haddon},
+  url           = {https://www.jstor.org/stable/26814587},
+  author        = {Vincent, Alana M.},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {3/4 (101/102)},
+  year          = {2008},
+  pages         = {101-116},
+}
+
+@article{mythlore:auger2008,
+  title         = {_Tolkien and Shakespeare: Essays on Shared Themes and Language_ by Janet Brennan Croft (review)},
+  url           = {https://www.jstor.org/stable/26814593},
+  author        = {Auger, Emily E.},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {3/4 (101/102)},
+  year          = {2008},
+  pages         = {199-201},
+}
+
+@article{mythlore:bratman2008,
+  title         = {_The Evolution of Tolkien’s Mythology: A Study of the History of Middle-earth_ by Elizabeth A. Whittingham (review)},
+  url           = {https://www.jstor.org/stable/26814594},
+  author        = {Bratman, David},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {3/4 (101/102)},
+  year          = {2008},
+  pages         = {201-203},
+}
+
+@article{mythlore:fisher2008a,
+  title         = {_The History of The Hobbit. Part One: Mr. Baggins; Part Two: Return to Bag-End_ by John D. Rateliff (review)},
+  url           = {https://www.jstor.org/stable/26814596},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {26},
+  number        = {3/4 (101/102)},
+  year          = {2008},
+  pages         = {206-212},
+}
+
+-- Mythlore. Vol. 27, No. 1/2 (103/104), Fall/Winter 2008
+-- https://www.jstor.org/stable/i26815532
+
+@article{mythlore:kellylivingston2008,
+  title         = {A Far Green Country: Tolkien, Paradise, and the End of All Things in Medieval Literature},
+  url           = {https://www.jstor.org/stable/26815562},
+  author        = {Kelly, A. Keith and Livingston, Michael},
+  journal       = {Mythlore},
+  volume        = {27},
+  number        = {1/2 (103/104)},
+  year          = {2008},
+  pages         = {83-102},
+}
+
+@article{mythlore:johnson2008,
+  title         = {Éowyn’s Grief},
+  url           = {https://www.jstor.org/stable/26815564},
+  author        = {Johnson, Brent D.},
+  journal       = {Mythlore},
+  volume        = {27},
+  number        = {1/2 (103/104)},
+  year          = {2008},
+  pages         = {117-127},
+}
+
+@article{mythlore:hawkins2008b,
+  title         = {Tolkien and Dogs, just Dogs: in Metaphor and Simile},
+  url           = {https://www.jstor.org/stable/26815566},
+  author        = {Hawkins, Emma B.},
+  journal       = {Mythlore},
+  volume        = {27},
+  number        = {1/2 (103/104)},
+  year          = {2008},
+  pages         = {143-157},
+}
+
+@article{mythlore:goodknight2008,
+  title         = {_Black & White Ogre Country: The Lost Tales of Hilary Tolkien_ by Angela Gardner, Jef Murray (review)},
+  url           = {https://www.jstor.org/stable/26815568},
+  author        = {GoodKnight, Glen},
+  journal       = {Mythlore},
+  volume        = {27},
+  number        = {1/2 (103/104)},
+  year          = {2008},
+  pages         = {167-168},
+}
+
+@article{mythlore:fisher2008b,
+  title         = {_Myth and Magic: Art according to the Inklings. Cormarë Series, No. 14_ by Eduardo Segura, Thomas Honegger (review)},
+  url           = {https://www.jstor.org/stable/26815572},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {27},
+  number        = {1/2 (103/104)},
+  year          = {2008},
+  pages         = {175-181},
+}
+
+@article{mythlore:crowe2008,
+  title         = {_The Mirror Crack’d: Fear and Horror in J~.R.~R Tolkien’s Major Works_ by Lynn Forest-Hill (review)},
+  url           = {https://www.jstor.org/stable/26815574},
+  author        = {Crowe, Edith L.},
+  journal       = {Mythlore},
+  volume        = {27},
+  number        = {1/2 (103/104)},
+  year          = {2008},
+  pages         = {186-188},
+}
+
+@article{mythlore:fisher2008c,
+  title         = {_Arda Reconstructed: The Creation of the Published Silmarillion_ by Douglas Charles Kane (review)},
+  url           = {https://www.jstor.org/stable/26815575},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {27},
+  number        = {1/2 (103/104)},
+  year          = {2008},
+  pages         = {189-195},
+}
+
+-- Mythlore. Vol. 28, No. 1/2 (107/108), Fall/Winter 2009
+-- https://www.jstor.org/stable/i26815443
+
+@article{mythlore:kinniburgh2009,
+  title         = {The Noldor and the Tuatha Dé Danaan: J.~R.~R. Tolkien’s Irish Influences},
+  url           = {https://www.jstor.org/stable/26815461},
+  author        = {Kinniburgh, Annie},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {1/2 (107/108)},
+  year          = {2009},
+  pages         = {27-44},
+}
+
+@article{mythlore:berube2009,
+  title         = {Tolkien’s "Sigurd & Gudrún": Summary, Sources, & Analogs},
+  url           = {https://www.jstor.org/stable/26815462},
+  author        = {Berube, Pierre H.},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {1/2 (107/108)},
+  year          = {2009},
+  pages         = {45-76},
+}
+
+@article{mythlore:croft2009,
+  title         = {Naming the Evil One: Onomastic Strategies in Tolkien and Rowling},
+  url           = {https://www.jstor.org/stable/26815468},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {1/2 (107/108)},
+  year          = {2009},
+  pages         = {149-163},
+}
+
+@article{mythlore:fisher2009,
+  title         = {_Projecting Tolkien’s Musical Worlds: A Study of Musical Affect in Howard Shore’s Soundtrack to Lord of the Rings_ by Matthew Young (review)},
+  url           = {https://www.jstor.org/stable/26815472},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {1/2 (107/108)},
+  year          = {2009},
+  pages         = {175-179},
+}
+
+-- Mythlore. Vol. 28, No. 3/4 (109/110), Spring/Summer 2010
+-- https://www.jstor.org/stable/i26814842
+
+@article{mythlore:nelson2010,
+  title         = {J.~R.~R. Tolkien’s _Leaf by Niggle_: An Allegory in Transformation},
+  url           = {https://www.jstor.org/stable/26814906},
+  author        = {Nelson, Marie},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {3/4 (109/110)},
+  year          = {2010},
+  pages         = {5-19},
+}
+
+@article{mythlore:derosariomartinez2010,
+  title         = {"Fairy" and "Elves" in Tolkien and Traditional Literature},
+  url           = {https://www.jstor.org/stable/26814912},
+  author        = {De Rosario Martínez, Helios},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {3/4 (109/110)},
+  year          = {2010},
+  pages         = {65-84},
+}
+
+@article{mythlore:brackmann2010,
+  title         = {"Dwarves Are Not Heroes": Antisemitism and the Dwarves in J.~R.~R. Tolkien’s Writing},
+  url           = {https://www.jstor.org/stable/26814913},
+  author        = {Brackmann, Rebecca},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {3/4 (109/110)},
+  year          = {2010},
+  pages         = {85-106},
+}
+
+@article{mythlore:kisor2010,
+  title         = {Totemic Reflexes in Tolkien’s Middle-earth},
+  url           = {https://www.jstor.org/stable/26814915},
+  author        = {Kisor, Yvette},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {3/4 (109/110)},
+  year          = {2010},
+  pages         = {129-140},
+}
+
+@article{mythlore:ruud2010,
+  title         = {The Voice of Saruman: Wizards and Rhetoric in _The Two Towers_},
+  url           = {https://www.jstor.org/stable/26814916},
+  author        = {Ruud, Jay},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {3/4 (109/110)},
+  year          = {2010},
+  pages         = {141-153},
+}
+
+@article{mythlore:waito2010,
+  title         = {The Shire Quest: The "Scouring of the Shire" as the Narrative and Thematic Focus of _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26814918},
+  author        = {Waito, David M.},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {3/4 (109/110)},
+  year          = {2010},
+  pages         = {155-177},
+}
+
+@article{mythlore:crowe2010,
+  title         = {_Where the Shadows Lie: A Jungian Interpretation of Tolkien’s The Lord of the Rings_ by Pia Skogemann (review)},
+  url           = {https://www.jstor.org/stable/26814920},
+  author        = {Crowe, Edith L.},
+  journal       = {Mythlore},
+  volume        = {28},
+  number        = {3/4 (109/110)},
+  year          = {2010},
+  pages         = {179-183},
+}
+
+-- Mythlore. Vol. 29, No. 1/2 (111/112), Fall/Winter 2010
+-- https://www.jstor.org/stable/i26815517
+
+@article{mythlore:fisher2010a,
+  title         = {Dwarves, Spiders, and Murky Woods: J.~R.~R. Tolkien’s Wonderful Web of Words},
+  url           = {https://www.jstor.org/stable/26815535},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {5-15},
+}
+
+@article{mythlore:tally2010,
+  title         = {Let Us Now Praise Famous Orcs: Simple Humanity in Tolkien’s Inhuman Creatures},
+  url           = {https://www.jstor.org/stable/26815537},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {17-28},
+}
+
+@article{mythlore:whitaker2010,
+  title         = {Corrupting beauty: rape narrative in _The Silmarillion_},
+  url           = {https://www.jstor.org/stable/26815539},
+  author        = {Whitaker, Lynn},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {51-68},
+}
+
+@article{mythlore:mitchell2010,
+  title         = {Master of Doom by Doom Mastered: Heroism, Fate, and Death in _The Children of Húrin_},
+  url           = {https://www.jstor.org/stable/26815541},
+  author        = {Mitchell, Jesse},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {87-114},
+}
+
+@article{mythlore:whitt2010,
+  title         = {Germanic "fate" and "doom" in J.~R.~R. Tolkien’s _The Silmarillion_},
+  url           = {https://www.jstor.org/stable/26815542},
+  author        = {Whitt, Richard J.},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {115-129},
+}
+
+@article{mythlore:croft2010,
+  title         = {The Thread on Which Doom Hangs: Free Will, Disobedience, and Eucatastrophe in Tolkien’s Middle-Earth},
+  url           = {https://www.jstor.org/stable/26815543},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {131-150},
+}
+
+@article{mythlore:stoddard2010,
+  title         = {"Simbelmynë": Mortality and Memory in Middle-Earth},
+  url           = {https://www.jstor.org/stable/26815544},
+  author        = {Stoddard, William H.},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {151-160},
+}
+
+@article{mythlore:berube2010,
+  title         = {The Origins of Dwarves},
+  url           = {https://www.jstor.org/stable/26815546},
+  author        = {Berube, Pierre H.},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {163-164},
+}
+
+@article{mythlore:fisher2010b,
+  title         = {_Tolkien, Race and Cultural History: From Fairies to Hobbits_ by Dimitra Fimi (review)},
+  url           = {https://www.jstor.org/stable/26815548},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {167-172},
+}
+
+@article{mythlore:moniz2010,
+  title         = {_Middle-earth Minstrel: Essays on Music in Tolkien_ by Bradford Lee Eden (review)},
+  url           = {https://www.jstor.org/stable/26815552},
+  author        = {Moniz, Emily A.},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {1/2 (111/112)},
+  year          = {2010},
+  pages         = {183-186},
+}
+
+-- Mythlore. Vol. 29, No. 3/4 (113/114), Spring/Summer 2011
+-- https://www.jstor.org/stable/i26814932
+
+@article{mythlore:grybauskas2011,
+  title         = {Dialogic War: From the Battle of Maldon to "the War of the Ring"},
+  url           = {https://www.jstor.org/stable/26815023},
+  author        = {Grybauskas, Peter},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {37-56},
+}
+
+@article{mythlore:milburn2011,
+  title         = {Art according to Romantic Theology: Charles Williams’s Analysis of Dance Reapplied to J.~R.~R. Tolkien’s _Leaf by Niggle_},
+  url           = {https://www.jstor.org/stable/26815024},
+  author        = {Milburn, Michael},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {57-75},
+}
+
+@article{mythlore:downey2011,
+  title         = {Cordial Dislike: Reinventing the Celestial Ladies of "Pearl" and "Purgatorio" in Tolkien’s Galadriel},
+  url           = {https://www.jstor.org/stable/26815026},
+  author        = {Downey, Sarah},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {101-117},
+}
+
+@article{mythlore:koubenec2011,
+  title         = {The Precious and the Pearl: The Influence of "Pearl" on the Nature of the One Ring},
+  url           = {https://www.jstor.org/stable/26815027},
+  author        = {Koubenec, Noah},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {119-131},
+}
+
+@article{mythlore:mcgregor2011,
+  title         = {Two Rings to Rule them All: A Comparative Study of Tolkien and Wagner},
+  url           = {https://www.jstor.org/stable/26815028},
+  author        = {McGregor, Jamie},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {133-153},
+}
+
+@article{mythlore:croft2011,
+  title         = {Túrin and Aragorn: Evading and Embracing Fate},
+  url           = {https://www.jstor.org/stable/26815029},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {155-170},
+}
+
+@article{mythlore:tally2011,
+  title         = {Stalin’s Orcs},
+  url           = {https://www.jstor.org/stable/26815030},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {171-172},
+}
+
+@article{mythlore:huttar2011,
+  title         = {_Tolkien’s The Lord of the Rings: Sources of Inspiration_ by Stratford Caldecott, Thomas Honegger (review)},
+  url           = {https://www.jstor.org/stable/26815035},
+  author        = {Huttar, Charles A.},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {192-195},
+}
+
+@article{mythlore:bratman2011,
+  title         = {_War of the Fantasy Worlds: C.~S. Lewis and J.~R.~R. Tolkien on Art and Imagination_ by Martha C. Sammons (review)},
+  url           = {https://www.jstor.org/stable/26815037},
+  author        = {Bratman, David},
+  journal       = {Mythlore},
+  volume        = {29},
+  number        = {3/4 (113/114)},
+  year          = {2011},
+  pages         = {198-200},
+}
+
+-- Mythlore. Vol. 30, No. 1/2 (115/116), Fall/Winter 2011
+-- https://www.jstor.org/stable/i26814786
+
+@article{mythlore:drout2011,
+  title         = {_Beowulf_: The Monsters and the Critics Seventy-Five Years Later},
+  url           = {https://www.jstor.org/stable/26814808},
+  author        = {Drout, Michael D. C.},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {1/2 (115/116)},
+  year          = {2011},
+  pages         = {5-22},
+}
+
+@article{mythlore:hallam2011,
+  title         = {Thresholds to Middle-earth: Allegories of Reading, Allegories for Knowledge and Transformation},
+  url           = {https://www.jstor.org/stable/26814809},
+  author        = {Hallam, Andrew},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {1/2 (115/116)},
+  year          = {2011},
+  pages         = {23-42},
+}
+
+@article{mythlore:auger2011,
+  title         = {_The Lord of the Rings_’ Interlace: The Adaptation to Film},
+  url           = {https://www.jstor.org/stable/26814816},
+  author        = {Auger, Emily E.},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {1/2 (115/116)},
+  year          = {2011},
+  pages         = {143-162},
+}
+
+@article{mythlore:sims2011,
+  title         = {_The Ring and the Cross: Christianity and The Lord of the Rings_ by Paul E. Kerry (review)},
+  url           = {https://www.jstor.org/stable/26814821},
+  author        = {Sims, Harley J.},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {1/2 (115/116)},
+  year          = {2011},
+  pages         = {176-181},
+}
+
+@article{mythlore:foster2011,
+  title         = {_Tolkien and the Study of His Sources: Critical Essays_ by Jason Fisher (review)},
+  url           = {https://www.jstor.org/stable/26814823},
+  author        = {Foster, Mike},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {1/2 (115/116)},
+  year          = {2011},
+  pages         = {189-192},
+}
+
+-- Mythlore. Vol. 30, No. 3/4 (117/118), Spring/Summer 2012
+-- https://www.jstor.org/stable/i26815479
+
+@article{mythlore:carter2012,
+  title         = {Faramir and the Heroic Ideal of the Twentieth Century; or, How Aragorn Died at the Somme},
+  url           = {https://www.jstor.org/stable/26815502},
+  author        = {Carter, Steven Brett},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {3/4 (117/118)},
+  year          = {2012},
+  pages         = {89-102},
+}
+
+@article{mythlore:bruce2012,
+  title         = {The Fall of Gondolin and the Fall of Troy: Tolkien and Book II of _The Aeneid_},
+  url           = {https://www.jstor.org/stable/26815503},
+  author        = {Bruce, Alexander M.},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {3/4 (117/118)},
+  year          = {2012},
+  pages         = {103-115},
+}
+
+@article{mythlore:livingston2012,
+  title         = {The Myths of the Author: Tolkien and the Medieval Origins of the Word "Hobbit"},
+  url           = {https://www.jstor.org/stable/26815505},
+  author        = {Livingston, Michael},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {3/4 (117/118)},
+  year          = {2012},
+  pages         = {129-146},
+}
+
+@article{mythlore:auger2012,
+  title         = {_Picturing Tolkien: Essays on Peter Jackson’s The Lord of the Rings Film Trilogy_ by Janice M. Bogstad, Philip E. Kaveny (review)},
+  url           = {https://www.jstor.org/stable/26815507},
+  author        = {Auger, Emily E.},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {3/4 (117/118)},
+  year          = {2012},
+  pages         = {151-152},
+}
+
+@article{mythlore:sims2012a,
+  title         = {_From Elvish to Klingon: Exploring Invented Languages_ by Michael Adams (review)},
+  url           = {https://www.jstor.org/stable/26815510},
+  author        = {Sims, Harley J.},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {3/4 (117/118)},
+  year          = {2012},
+  pages         = {159-168},
+}
+
+@article{mythlore:brown2012a,
+  title         = {_Tolkien and Wales: Language, Literature, and Identity_ by Carl Phelpstead (review)},
+  url           = {https://www.jstor.org/stable/26815513},
+  author        = {Brown, Sara},
+  journal       = {Mythlore},
+  volume        = {30},
+  number        = {3/4 (117/118)},
+  year          = {2012},
+  pages         = {173-182},
+}
+
+-- Mythlore. Vol. 31, No. 1/2 (119/120), Fall/Winter 2012
+-- https://www.jstor.org/stable/i40240901
+
+@article{mythlore:bridgwater2012,
+  title         = {The Steward, the King, and the Queen: Fealty and Love in Tolkien’s _The Lord of the Rings_ and in _Sir Orfeo_},
+  url           = {https://www.jstor.org/stable/45492719},
+  author        = {Bridgwater, Sue},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {1/2 (119/120)},
+  year          = {2012},
+  pages         = {49-70},
+}
+
+@article{mythlore:sims2012b,
+  title         = {_Tolkien in Translation_ by Thomas Honegger (review)},
+  url           = {https://www.jstor.org/stable/45492730},
+  author        = {Sims, Harley J.},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {1/2 (119/120)},
+  year          = {2012},
+  pages         = {173-177},
+}
+
+@article{mythlore:brown2012b,
+  title         = {_Translating Tolkien: Text and Film_ by Thomas Honegger (review)},
+  url           = {https://www.jstor.org/stable/45492731},
+  author        = {Brown, Sara},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {1/2 (119/120)},
+  year          = {2012},
+  pages         = {177-184},
+}
+
+@article{mythlore:ordway2012,
+  title         = {_The Loss and the Silence: Aspects of Modernism in the Works of C.~S. Lewis by J.~R.~R. Tolkien, Charles Williams_ (review)},
+  url           = {https://www.jstor.org/stable/45492734},
+  author        = {Ordway, Holly},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {1/2 (119/120)},
+  year          = {2012},
+  pages         = {190-193},
+}
+
+-- Mythlore. Vol. 31, No. 3/4 (121/122), Spring/Summer 2013
+-- https://www.jstor.org/stable/i26815814
+
+@article{mythlore:lionarons2013,
+  title         = {Of Spiders and Elves},
+  url           = {https://www.jstor.org/stable/26815863},
+  author        = {Lionarons, Joyce Tally},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {3/4 (121/122)},
+  year          = {2013},
+  pages         = {5-13},
+}
+
+@article{mythlore:birns2013,
+  title         = {"The Inner Consistency of Reality": Intermediacy in _The Hobbit_},
+  url           = {https://www.jstor.org/stable/26815864},
+  author        = {Birns, Nicholas},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {3/4 (121/122)},
+  year          = {2013},
+  pages         = {15-30},
+}
+
+@article{mythlore:long2013,
+  title         = {Disparaging Narnia: Reconsidering Tolkien’s View of _The Lion, the Witch and the Wardrobe_},
+  url           = {https://www.jstor.org/stable/26815865},
+  author        = {Long, Josh B.},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {3/4 (121/122)},
+  year          = {2013},
+  pages         = {31-46},
+}
+
+@article{mythlore:saxton2013,
+  title         = {J.~R.~R. Tolkien, Sub-Creation, and Theories of Authorship},
+  url           = {https://www.jstor.org/stable/26815866},
+  author        = {Saxton, Benjamin},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {3/4 (121/122)},
+  year          = {2013},
+  pages         = {47-59},
+}
+
+@article{mythlore:mitchell2013,
+  title         = {"But grace is not infinite": Tolkien’s Explorations of Nature and Grace in His Catholic Context},
+  url           = {https://www.jstor.org/stable/26815867},
+  author        = {Mitchell, Phillip Irving},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {3/4 (121/122)},
+  year          = {2013},
+  pages         = {61-81},
+}
+
+@article{mythlore:christie2013,
+  title         = {Sméagol and Déagol: Secrecy, History, and Ethical Subjectivity in Tolkien’s World},
+  url           = {https://www.jstor.org/stable/26815868},
+  author        = {Christie, E. J.},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {3/4 (121/122)},
+  year          = {2013},
+  pages         = {83-101},
+}
+
+@article{mythlore:forchhammer2013,
+  title         = {_Hobbit Place-names: A Linguistic Excursion Through the Shire_ by Rainer Nagel (review)},
+  url           = {https://www.jstor.org/stable/26815876},
+  author        = {Forchhammer, Troels},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {3/4 (121/122)},
+  year          = {2013},
+  pages         = {127-129},
+}
+
+@article{mythlore:sims2013,
+  title         = {_The Broken Scythe: Death and Immortality in the Works of J.~R.~R. Tolkien_ by Roberto Arduini, Claudio A. Testi (review)},
+  url           = {https://www.jstor.org/stable/26815877},
+  author        = {Sims, Harley J.},
+  journal       = {Mythlore},
+  volume        = {31},
+  number        = {3/4 (121/122)},
+  year          = {2013},
+  pages         = {129-136},
+}
+
+-- Mythlore. Vol. 32, No. 1 (123), Fall/Winter 2013
+-- https://www.jstor.org/stable/i26815840
+
+@article{mythlore:abrahamson2013,
+  title         = {J.~R.~R. Tolkien, Fanfiction, and "the Freedom of the Reader"},
+  url           = {https://www.jstor.org/stable/26815846},
+  author        = {Abrahamson, Megan B.},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {1 (123)},
+  year          = {2013},
+  pages         = {53-72},
+}
+
+@article{mythlore:livingston2013,
+  title         = {Troy and the Rings: Tolkien and the Medieval Myth of England},
+  url           = {https://www.jstor.org/stable/26815847},
+  author        = {Livingston, Michael},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {1 (123)},
+  year          = {2013},
+  pages         = {73-91},
+}
+
+@article{mythlore:mcgregor2013,
+  title         = {Tolkien’s Devices: The Heraldry of Middle-earth},
+  url           = {https://www.jstor.org/stable/26815848},
+  author        = {McGregor, Jamie},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {1 (123)},
+  year          = {2013},
+  pages         = {93-110},
+}
+
+@article{mythlore:madsen2013,
+  title         = {Theological Reticence and Moral Radiance: Notes on Tolkien, Levinas, and Inuit Cosmology},
+  url           = {https://www.jstor.org/stable/26815849},
+  author        = {Madsen, Catherine},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {1 (123)},
+  year          = {2013},
+  pages         = {111-126},
+}
+
+@article{mythlore:swank2013,
+  title         = {_The Hobbit_ and _the Father Christmas Letters_},
+  url           = {https://www.jstor.org/stable/26815850},
+  author        = {Swank, Kris},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {1 (123)},
+  year          = {2013},
+  pages         = {127-144},
+}
+
+@article{mythlore:tally2013,
+  title         = {_The International Relations of Middle-earth: Learning from The Lord of the Rings_ by Abigail E. Ruane, Patrick James (review)},
+  url           = {https://www.jstor.org/stable/26815851},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {1 (123)},
+  year          = {2013},
+  pages         = {145-151},
+}
+
+@article{mythlore:bador2013,
+  title         = {_Moments of Grace and Spiritual Warfare in The Lord of the Rings_ by Anne Marie Gazzolo (review)},
+  url           = {https://www.jstor.org/stable/26815852},
+  author        = {Bador, Damien},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {1 (123)},
+  year          = {2013},
+  pages         = {152-155},
+}
+
+@article{mythlore:christopher2013,
+  title         = {_Tolkien’s Poetry. Cormarë Series, No. 28_ by Julian Eilmann, Allan Turner (review)},
+  url           = {https://www.jstor.org/stable/26815855},
+  author        = {Christopher, Joe R.},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {1 (123)},
+  year          = {2013},
+  pages         = {162-167},
+}
+
+-- Mythlore. Vol. 32, No. 2 (124), Spring/Summer 2014
+-- https://www.jstor.org/stable/i26815812
+
+@article{mythlore:bunting2014,
+  title         = {Tolkien in Love: Pictures from Winter 1912-1913},
+  url           = {https://www.jstor.org/stable/26815817},
+  author        = {Bunting, Nancy},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {2 (124)},
+  year          = {2014},
+  pages         = {5-12},
+}
+
+@article{mythlore:croft2014a,
+  title         = {Tolkien’s Faërian Drama: Origins and Valedictions},
+  url           = {https://www.jstor.org/stable/26815819},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {2 (124)},
+  year          = {2014},
+  pages         = {31-45},
+}
+
+@article{mythlore:riga2014,
+  title         = {From Children’s Book to Epic Prequel: Peter Jackson’s Transformation of Tolkien’s _The Hobbit_},
+  url           = {https://www.jstor.org/stable/26815823},
+  author        = {Riga, Frank P. and Thum, Maureen and Kollmann, Judith},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {2 (124)},
+  year          = {2014},
+  pages         = {97-116},
+}
+
+@article{mythlore:long2014,
+  title         = {Pillaging Middle-earth: Self-Plagiarism in _Smith of Wootton Major_},
+  url           = {https://www.jstor.org/stable/26815824},
+  author        = {Long, Josh B.},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {2 (124)},
+  year          = {2014},
+  pages         = {117-135},
+}
+
+@article{mythlore:garrad2014,
+  title         = {_The Riddles of The Hobbit_ by Adam Roberts (review)},
+  url           = {https://www.jstor.org/stable/26815830},
+  author        = {Garrad, Jon},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {2 (124)},
+  year          = {2014},
+  pages         = {177-180},
+}
+
+@article{mythlore:green2014,
+  title         = {_The Ideal of Kingship in the Writings of Charles Williams, C.~S. Lewis, and J.~R.~R. Tolkien: Divine Kingship is Reflected in Middle-earth_ by Christopher Scarf},
+  url           = {https://www.jstor.org/stable/26815834},
+  author        = {Green, Melody},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {2 (124)},
+  year          = {2014},
+  pages         = {189-191},
+}
+
+@article{mythlore:foster2014,
+  title         = {_The Ring of Words: Tolkien and The Oxford English Dictionary_ by Peter Gilliver, Jeremy Marshall, Edmund Weiner (review)},
+  url           = {https://www.jstor.org/stable/26815835},
+  author        = {Foster, Mike},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {2 (124)},
+  year          = {2014},
+  pages         = {192-194},
+}
+
+
+@article{mythlore:miller2014,
+  title         = {_Tolkien: The Forest and the City_ by Helen Conrad-O’Briain, Gerard Hynes (review)},
+  url           = {https://www.jstor.org/stable/26815836},
+  author        = {Miller, T. S.},
+  journal       = {Mythlore},
+  volume        = {32},
+  number        = {2 (124)},
+  year          = {2014},
+  pages         = {194-198},
+}
+
+-- Mythlore. Vol. 33, No. 1 (125), Fall/Winter 2014
+-- https://www.jstor.org/stable/i26815813
+
+@article{mythlore:west2014,
+  title         = {Where Fantasy Fits: The Importance of Being Tolkien},
+  url           = {https://www.jstor.org/stable/26815938},
+  author        = {West, Richard C.},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {1 (125)},
+  year          = {2014},
+  pages         = {5-36},
+}
+
+@article{mythlore:post2014,
+  title         = {Perilous Wanderings through the Enchanted Forest: The Influence of the Fairy-Tale Tradition on Mirkwood in Tolkien’s _The Hobbit_},
+  url           = {https://www.jstor.org/stable/26815941},
+  author        = {Post, Marco R. S.},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {1 (125)},
+  year          = {2014},
+  pages         = {67-84},
+}
+
+@article{mythlore:nardi2014,
+  title         = {Political Institutions in J.~R.~R. Tolkien’s Middle-earth: Or, How I Learned to Stop Worrying About the Lack of Democracy},
+  url           = {https://www.jstor.org/stable/26815943},
+  author        = {Nardi, Dominic J.},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {1 (125)},
+  year          = {2014},
+  pages         = {101-123},
+}
+
+@article{mythlore:croft2014b,
+  title         = {_The Body in Tolkien’s Legendarium: Essays on Middle-earth Corporeality_ by Christopher Vaccaro (review)},
+  url           = {https://www.jstor.org/stable/26815946},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {1 (125)},
+  year          = {2014},
+  pages         = {146-149},
+}
+
+@article{mythlore:higgins2014,
+  title         = {_In the Nameless Wood: Explorations in the Philological Hinterland of Tolkien’s Literary Creations. Cormare Series. No. 30_ by J.~S. Ryan, Peter Buchs (review)},
+  url           = {https://www.jstor.org/stable/26815949},
+  author        = {Higgins, Andrew S.},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {1 (125)},
+  year          = {2014},
+  pages         = {153-163},
+}
+
+-- Mythlore. Vol. 33, No. 2 (126), Spring/Summer 2015
+-- https://www.jstor.org/stable/i26815983
+
+@article{mythlore:viars2015,
+  title         = {Constructing Lothiriel: Rewriting and Rescuing the Women of Middle-earth from the Margins},
+  url           = {https://www.jstor.org/stable/26815988},
+  author        = {Viars, Karen and Coker, Cait},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {2 (126)},
+  year          = {2015},
+  pages         = {35-48},
+}
+
+@article{mythlore:holtz-wodzak2015,
+  title         = {Tolkien Sidelined: Constructing the Non-combatant in _The Children of Hurin_},
+  url           = {https://www.jstor.org/stable/26815991},
+  author        = {Holtz-Wodzak, Victoria},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {2 (126)},
+  year          = {2015},
+  pages         = {93-109},
+}
+
+@article{mythlore:rosegrant2015,
+  title         = {Tolkien’s Dialogue Between Enchantment and Loss},
+  url           = {https://www.jstor.org/stable/26815993},
+  author        = {Rosegrant, John},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {2 (126)},
+  year          = {2015},
+  pages         = {127-138},
+}
+
+@article{mythlore:tarcsay2015,
+  title         = {"Chaoskampf", Salvation, and Dragons: Archetypes in Tolkien’s Earendel},
+  url           = {https://www.jstor.org/stable/26815994},
+  author        = {Tarcsay, Tibor},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {2 (126)},
+  year          = {2015},
+  pages         = {139-150},
+}
+
+@article{mythlore:martsch2015,
+  title         = {Thiepval Ridge and Minas Tirith},
+  url           = {https://www.jstor.org/stable/26815995},
+  author        = {Martsch, Nancy},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {2 (126)},
+  year          = {2015},
+  pages         = {151-154},
+}
+
+@article{mythlore:auger2015,
+  title         = {_The Shamanic Odyssey: Homer, Tolkien, and the Visionary Experience_ by Robert Tindall, Susana Bustos, John Perkins (review)},
+  url           = {https://www.jstor.org/stable/26816000},
+  author        = {Auger, Emily E.},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {2 (126)},
+  year          = {2015},
+  pages         = {161-163},
+}
+
+@article{mythlore:tally2015,
+  title         = {_Tolkien and the Modernists: Literary Responses to the Dark New Days of the 20 th Century_ by Theresa Freda Nicolay (review)},
+  url           = {https://www.jstor.org/stable/26816004},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {2 (126)},
+  year          = {2015},
+  pages         = {171-175},
+}
+
+@article{mythlore:foster2015,
+  title         = {_Tolkien at Exeter College: How an Oxford undergraduate Created Middle-earth_ by John Garth (review)},
+  url           = {https://www.jstor.org/stable/26816005},
+  author        = {Foster, Mike},
+  journal       = {Mythlore},
+  volume        = {33},
+  number        = {2 (126)},
+  year          = {2015},
+  pages         = {175-180},
+}
+
+-- Mythlore. Vol. 34, No. 1 (127), Fall/Winter 2015
+-- https://www.jstor.org/stable/i26815786
+
+@article{mythlore:branchaw2015,
+  title         = {Tolkien’s Philological Philosophy in His Fiction},
+  url           = {https://www.jstor.org/stable/26815790},
+  author        = {Branchaw, Sherrylyn},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {1 (127)},
+  year          = {2015},
+  pages         = {37-50},
+}
+
+@article{mythlore:fitzsimmons2015,
+  title         = {Tales of Anti-Heroes in the Work of J.~R.~R. Tolkien},
+  url           = {https://www.jstor.org/stable/26815791},
+  author        = {Fitzsimmons, Phillip},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {1 (127)},
+  year          = {2015},
+  pages         = {51-58},
+}
+
+@article{mythlore:bunting2015,
+  title         = {1904: Tolkien, Trauma, and its Anniversaries},
+  url           = {https://www.jstor.org/stable/26815792},
+  author        = {Bunting, Nancy},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {1 (127)},
+  year          = {2015},
+  pages         = {59-81},
+}
+
+@article{mythlore:lakowski2015,
+  title         = {"A Wilderness of Dragons": Tolkien’s Treatment of Dragons in _Roverandom_ and _Farmer Giles of Ham_},
+  url           = {https://www.jstor.org/stable/26815793},
+  author        = {Lakowski, Romuald Ian},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {1 (127)},
+  year          = {2015},
+  pages         = {83-103},
+}
+
+@article{mythlore:croft2015,
+  title         = {"Noms de Guerre": The Power of Naming in War and Conflict in Middle-Earth},
+  url           = {https://www.jstor.org/stable/26815794},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {1 (127)},
+  year          = {2015},
+  pages         = {105-115},
+}
+
+@article{mythlore:agan2015,
+  title         = {Hearkening to the Other: a Certeauvian Reading of the _Ainulindalë_},
+  url           = {https://www.jstor.org/stable/26815795},
+  author        = {Agan, Cami D.},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {1 (127)},
+  year          = {2015},
+  pages         = {117-138},
+}
+
+@article{mythlore:kisor2015,
+  title         = {_Anglo-Saxon Community in J.~R.~R. Tolkien’s The Lord of the Rings_ by Deborah A. Higgins (review)},
+  url           = {https://www.jstor.org/stable/26815800},
+  author        = {Kisor, Yvette},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {1 (127)},
+  year          = {2015},
+  pages         = {163-165},
+}
+
+@article{mythlore:larson2015,
+  title         = {_Arda Inhabited: Environmental Relationships in The Lord of the Rings_ by Susan Jeffers (review)},
+  url           = {https://www.jstor.org/stable/26815802},
+  author        = {Larson, Jeremy},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {1 (127)},
+  year          = {2015},
+  pages         = {171-176},
+}
+
+-- Mythlore. Vol. 34, No. 2 (128), Spring/Summer 2016
+-- https://www.jstor.org/stable/i26816013
+
+@article{mythlore:kelly2016,
+  title         = {Breaking the Dragon’s Gaze: Commodity Fetishism in Tolkien’s Middle-earth},
+  url           = {https://www.jstor.org/stable/26816038},
+  author        = {Kelly, Steven},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {2 (128)},
+  year          = {2016},
+  pages         = {113-132},
+}
+
+@article{mythlore:miller2016,
+  title         = {Mapping Gender in Middle-earth},
+  url           = {https://www.jstor.org/stable/26816039},
+  author        = {Miller, John},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {2 (128)},
+  year          = {2016},
+  pages         = {133-152},
+}
+
+@article{mythlore:jarman2016,
+  title         = {The Black Speech: _The Lord of the Rings_ as a Modern Linguistic Critique},
+  url           = {https://www.jstor.org/stable/26816040},
+  author        = {Jarman, Cody},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {2 (128)},
+  year          = {2016},
+  pages         = {153-166},
+}
+
+@article{mythlore:rosegrant2016,
+  title         = {A Comment on "1904: Tolkien, Trauma, and its Anniversaries"},
+  url           = {https://www.jstor.org/stable/26816041},
+  author        = {Rosegrant, John},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {2 (128)},
+  year          = {2016},
+  pages         = {167-170},
+}
+
+@article{mythlore:stout2016,
+  title         = {_Tolkien Among the Moderns_ by Ralph C. Wood (review)},
+  url           = {https://www.jstor.org/stable/26816046},
+  author        = {Stout, Andrew C.},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {2 (128)},
+  year          = {2016},
+  pages         = {181-184},
+}
+
+@article{mythlore:coker2016,
+  title         = {_Tolkien_ by Raymond Edwards (review)},
+  url           = {https://www.jstor.org/stable/26816047},
+  author        = {Coker, Cait},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {2 (128)},
+  year          = {2016},
+  pages         = {184-186},
+}
+
+@article{mythlore:croft2016,
+  title         = {_Hither Shore: Jahrbuch der Deutschen Tolkien Gesellschaft. Special issue: Nature and Landscape in Tolkien_ by Thomas Fornet-Ponse (review)},
+  url           = {https://www.jstor.org/stable/26816051},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {2 (128)},
+  year          = {2016},
+  pages         = {195-204},
+}
+
+@article{mythlore:foster2016a,
+  title         = {_The Story of Kullervo_ by J.~R.~R. Tolkien, Verlyn Flieger (review)},
+  url           = {https://www.jstor.org/stable/26816054},
+  author        = {Foster, Mike},
+  journal       = {Mythlore},
+  volume        = {34},
+  number        = {2 (128)},
+  year          = {2016},
+  pages         = {207-212},
+}
+
+-- Mythlore. Vol. 35, No. 1 (129), Fall/Winter 2016
+-- https://www.jstor.org/stable/i40240902
+
+@article{mythlore:boenig2016,
+  title         = {The Face of the Materialist Magician: Lewis, Tolkien, and the Art of Crossing Perilous Streets},
+  url           = {https://www.jstor.org/stable/45492741},
+  author        = {Boenig, Robert},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {1 (129)},
+  year          = {2016},
+  pages         = {5-22},
+}
+
+@article{mythlore:comer2016,
+  title         = {The Disabled Hero: Being and Ethics in Peter Jackson’s _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/45492747},
+  author        = {Comer, Todd A.},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {1 (129)},
+  year          = {2016},
+  pages         = {113-131},
+}
+
+@article{mythlore:martin2016,
+  title         = {_Bandersnatch: C.~S. Lewis, J.~R.~R. Tolkien, and the Creative Collaboration of the Inklings_ by Diana Pavlac Glyer, James A. Owen (review)},
+  url           = {https://www.jstor.org/stable/45492750},
+  author        = {Martin, Tiffany Brooke},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {1 (129)},
+  year          = {2016},
+  pages         = {144-146},
+}
+
+@article{mythlore:foster2016b,
+  title         = {_High towers and strong places: A political history of Middle-earth_ by Timothy R. Furnish, Anke Eißmann, Aaron Siddall (review)},
+  url           = {https://www.jstor.org/stable/45492752},
+  author        = {Foster, Mike},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {1 (129)},
+  year          = {2016},
+  pages         = {147-151},
+}
+
+@article{mythlore:green2016,
+  title         = {_Approaches to Teaching Tolkien’s The Lord of the Rings and Other Works_ by Leslie A. Donovan (review)},
+  url           = {https://www.jstor.org/stable/45492762},
+  author        = {Green, Melody},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {1 (129)},
+  year          = {2016},
+  pages         = {188-190},
+}
+
+@article{mythlore:fisher2016,
+  title         = {_A Companion to J.~R.~R. Tolkien_ by Stuart D. Lee (review)},
+  url           = {https://www.jstor.org/stable/45492763},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {1 (129)},
+  year          = {2016},
+  pages         = {191-200},
+}
+
+-- Mythlore. Vol. 35, No. 2 (130), Spring/Summer 2017
+-- https://www.jstor.org/stable/i26816061
+
+@article{mythlore:duplessis2017,
+  title         = {To Grow Together, or to Grow Apart: The Long Sorrow of the Ents and Marriage in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26816083},
+  author        = {duPlessis, Nicole M.},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {2 (130)},
+  year          = {2017},
+  pages         = {25-44},
+}
+
+@article{mythlore:alberto2017,
+  title         = {"It had been his virtue, and therefore also the cause of his fall": Seduction as a Mythopoeic Accounting for Evil in Tolkien’s Work},
+  url           = {https://www.jstor.org/stable/26816085},
+  author        = {Alberto, Maria K.},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {2 (130)},
+  year          = {2017},
+  pages         = {63-79},
+}
+
+@article{mythlore:croft2017a,
+  title         = {The Name of the Ring: Or, There and Back Again},
+  url           = {https://www.jstor.org/stable/26816086},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {2 (130)},
+  year          = {2017},
+  pages         = {81-94},
+}
+
+@article{mythlore:chandler2017,
+  title         = {Tolkien’s Allusive Backstory: Immortality and Belief in the Fantasy Frame},
+  url           = {https://www.jstor.org/stable/26816087},
+  author        = {Chandler, Wayne A. and Fry, Carrol L.},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {2 (130)},
+  year          = {2017},
+  pages         = {95-113},
+}
+
+@article{mythlore:rosegrant2017,
+  title         = {From the Ineluctable Wave to the Realization of Imagined Wonder: Tolkien’s Transformation of Psychic Pain into Art},
+  url           = {https://www.jstor.org/stable/26816089},
+  author        = {Rosegrant, John},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {2 (130)},
+  year          = {2017},
+  pages         = {133-152},
+}
+
+@article{mythlore:fisher2017,
+  title         = {_A Secret Vice: Tolkien on Invented Languages_ by J.~R.~R. Tolkien, Dimitra Fimi, Andrew Higgins (review)},
+  url           = {https://www.jstor.org/stable/26816091},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {2 (130)},
+  year          = {2017},
+  pages         = {171-175},
+}
+
+@article{mythlore:foster2017,
+  title         = {_A Well of Wonder: Essays on C.~S. Lewis, J.~R.~R. Tolkien, and the Inklings_ by Clyde S. Kilby, Loren Wilkinson, Keith Call (review)},
+  url           = {https://www.jstor.org/stable/26816097},
+  author        = {Foster, Mike},
+  journal       = {Mythlore},
+  volume        = {35},
+  number        = {2 (130)},
+  year          = {2017},
+  pages         = {193-199},
+}
+
+-- Mythlore. Vol. 36, No. 1 (131), Fall/Winter 2017
+-- https://www.jstor.org/stable/e26809251
+
+@article{mythlore:fliss2017,
+  title         = {"Things that Were, and Things that Are, and Things that Yet May Be": The J.~R.~R. Tolkien Manuscript Collection at Marquette University},
+  url           = {https://www.jstor.org/stable/26809255},
+  author        = {Fliss, William M.},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {21-38},
+}
+
+
+@article{mythlore:vaccaro2017,
+  title         = {"Morning Stars of a Setting World": Alain de Lille’s _De Planctu Naturæ_ and Tolkien’s Legendarium as Neo-Platonic Mythopoeia},
+  url           = {https://www.jstor.org/stable/26809258},
+  author        = {Vaccaro, Christopher},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {81-102},
+}
+
+@article{mythlore:bergen2017,
+  title         = {"A Warp of Horror": J.~R.~R. Tolkien’s Sub-creations of Evil},
+  url           = {https://www.jstor.org/stable/26809259},
+  author        = {Bergen, Richard Angelo},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {103-122},
+}
+
+@article{mythlore:wise2017,
+  title         = {J.~R.~R. Tolkien and the 1954 Nomination of E.~M. Forster for the Nobel Prize in Literature},
+  url           = {https://www.jstor.org/stable/26809261},
+  author        = {Wise, Dennis Wilson},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {143-166},
+}
+
+@article{mythlore:tally2017,
+  title         = {Three Rings for the Elven-kings: Trilogizing Tolkien in Print and Film},
+  url           = {https://www.jstor.org/stable/26809264},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {175-190},
+}
+
+@article{mythlore:neville2017,
+  title         = {_Beren and Lúthien by J.~R.~R. Tolkien,_ Christopher Tolkien, Alan Lee (review)},
+  url           = {https://www.jstor.org/stable/26809271},
+  author        = {Neville, Katherine},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {209-213},
+}
+
+@article{mythlore:mitchell2017,
+  title         = {_Tolkien’s Theology of Beauty: Majesty, Splendour, and Transcendence in Middle-earth_ by Lisa Coutras (review)},
+  url           = {https://www.jstor.org/stable/26809272},
+  author        = {Mitchell, Phillip Irving},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {213-219},
+}
+
+@article{mythlore:croft2017b,
+  title         = {_Laughter in Middle-earth: Humour In and Around the Works of J.~R.~R. Tolkien_ by Thomas Honegger, Maureen F. Mann (review)},
+  url           = {https://www.jstor.org/stable/26809274},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {221-224},
+}
+
+@article{mythlore:emerson2017,
+  title         = {_From Peterborough to Faëry: The Poetics and Mechanics of Secondary Worlds_ by Thomas Honegger, Dirk Vanderbeke (review)},
+  url           = {https://www.jstor.org/stable/26809276},
+  author        = {Emerson, David},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {227-229},
+}
+
+@article{mythlore:croft2017c,
+  title         = {_Orcrist #9 (2017). The Bulletin of the Tolkien and Fantasy Society at the University of Wisconsin—Madison. 50th Anniversary Issue_ by Richard C. West, Lucas Annear, Jack Mathie (review)},
+  url           = {https://www.jstor.org/stable/26809282},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {1 (131)},
+  year          = {2017},
+  pages         = {249-250},
+}
+
+-- Mythlore. Vol. 36, No. 2 (132), Spring/Summer 2018
+-- https://www.jstor.org/stable/e26809288
+
+@article{mythlore:costabile2018,
+  title         = {Bilbo Baggins and the Forty Thieves: The Reworking of Folktale Motifs in _The Hobbit_ (and _The Lord of the Rings_)},
+  url           = {https://www.jstor.org/stable/26809295},
+  author        = {Costabile, Giovanni C.},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {2 (132)},
+  year          = {2018},
+  pages         = {89-104},
+}
+
+@article{mythlore:swank2018,
+  title         = {_J.~R.~R. Tolkien: Romanticist and Poet, Cormarë Series No. 36_ by Julian Eilmann, Evelyn Koch (review)},
+  url           = {https://www.jstor.org/stable/26809298},
+  author        = {Swank, Kris},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {2 (132)},
+  year          = {2018},
+  pages         = {113-121},
+}
+
+@article{mythlore:tredray2018,
+  title         = {Divination and Prophecy in _The Lord of the Rings_: Some Observations},
+  url           = {https://www.jstor.org/stable/26809314},
+  author        = {Tredray, Robert Field},
+  journal       = {Mythlore},
+  volume        = {36},
+  number        = {2 (132)},
+  year          = {2018},
+  pages         = {251-258},
+}
+
+-- Mythlore. Vol. 37, No. 1 (133), Fall/Winter 2018
+-- https://www.jstor.org/stable/e26809318
+
+@article{mythlore:fontenot2018,
+  title         = {"No Pagan Ever Loved His God": Tolkien, Thompson, and the Beautification of the Gods},
+  url           = {https://www.jstor.org/stable/26809323},
+  author        = {Fontenot, Megan N.},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {45-62},
+}
+
+@article{mythlore:cutler2018,
+  title         = {Turning Back the Tides: the Anglo-Saxon Vice of Ofermod in Tolkien’s _Fall of Arthur_},
+  url           = {https://www.jstor.org/stable/26809324},
+  author        = {Cutler, Colin J.},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {63-80},
+}
+
+@article{mythlore:donnelly2018,
+  title         = {Nazis in the Shire: Tolkien and Satire},
+  url           = {https://www.jstor.org/stable/26809325},
+  author        = {Donnelly, Jerome},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {81-102},
+}
+
+@article{mythlore:wodzak2018,
+  title         = {Tolkien’s Gimpy Heroes},
+  url           = {https://www.jstor.org/stable/26809326},
+  author        = {Holtz-Wodzak, Victoria},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {103-118},
+}
+
+@article{mythlore:olson2018,
+  title         = {A Cloud of Witnesses: External Mediation in Frodo’s Journey to Rivendell and Beyond},
+  url           = {https://www.jstor.org/stable/26809327},
+  author        = {Olson, Carl P.},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {119-132},
+}
+
+@article{mythlore:martsch2018,
+  title         = {On Julian Eilmann’s _J.~R.~R. Tolkien: Romanticist and Poet_, Reviewed by Kris Swank in Mythlore #132},
+  url           = {https://www.jstor.org/stable/26809333},
+  author        = {Martsch, Nancy},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {212-213},
+}
+
+@article{mythlore:berube2018,
+  title         = {Bilingual Puns in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26809334},
+  author        = {Berube, Pierre H.},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {213-216},
+}
+
+@article{mythlore:bolding2018,
+  title         = {_Christian Mythmakers: C.~S. Lewis, Madeleine L’Engle, J.~R.~R. Tolkien, George Macdonald, G.~K. Chesterton, Charles Williams, Dante Alighieri, John Bunyan, Walter Wangerin, Robert Siegel, and Hannah Hurnard._ 2nd ed. by Rolland Hein, Clyde S. Kilby},
+  url           = {https://www.jstor.org/stable/26809337},
+  author        = {Bolding, Sharon L.},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {223-227},
+}
+
+@article{mythlore:foster2018,
+  title         = {_Death and Immortality in Middle-earth: Proceedings of the Tolkien Society Seminar 2016_ by Daniel Helen},
+  url           = {https://www.jstor.org/stable/26809338},
+  author        = {Foster, Mike},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {227-230},
+}
+
+@article{mythlore:emerson2018,
+  title         = {_The Hobbit and Tolkien’s Mythology_ by Bradford Lee Eden},
+  url           = {https://www.jstor.org/stable/26809342},
+  author        = {Emerson, David},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {242-248},
+}
+
+@article{mythlore:baker2018,
+  title         = {_Poetry and Song in The Works Of J.~R.~R. Tolkien._ (2018) by Anna Milon},
+  url           = {https://www.jstor.org/stable/26809344},
+  author        = {Baker, Diane Joy},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {252-253},
+}
+
+@article{mythlore:croft2018,
+  title         = {_Tolkien: Maker of Middle-Earth_ by Catherine McIlwaine},
+  url           = {https://www.jstor.org/stable/26809345},
+  author        = {Croft, Janet Brennan},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {1 (133)},
+  year          = {2018},
+  pages         = {254-255},
+}
+
+-- Mythlore. Vol. 37, No. 2 (134), Spring/Summer 2019, 50th Anniversary Issue
+-- https://www.jstor.org/stable/e26809349
+
+@article{mythlore:reid2019,
+  title         = {On the Shoulders of Gi(E)nts: The Joys of Bibliographic Scholarship and Fanzines in Tolkien Studies},
+  url           = {https://www.jstor.org/stable/26809353},
+  author        = {Reid, Robin A.},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {2 (134)},
+  year          = {2019},
+  pages         = {23-38},
+}
+
+@article{mythlore:duplessis2019,
+  title         = {On the Shoulders of Humphrey Carpenter: Reconsidering Biographical Representation and Scholarly Perception of Edith Tolkien},
+  url           = {https://www.jstor.org/stable/26809354},
+  author        = {duPlessis, Nicole M.},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {2 (134)},
+  year          = {2019},
+  pages         = {39-74},
+}
+
+@article{mythlore:chisholm2019,
+  title         = {Saruman as "Sophist" or Sophist Foil? Tolkien’s Wizards and the Ethics of Persuasion},
+  url           = {https://www.jstor.org/stable/26809356},
+  author        = {Chisholm, Chad},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {2 (134)},
+  year          = {2019},
+  pages         = {89-102},
+}
+
+@article{mythlore:higgins2019,
+  title         = {Inklings, a King, and an Unsurprising Prize: _The Inklings and King Arthur: J.~R.~R. Tolkien, Charles Williams, C.~S. Lewis, and Owen Barfield on the Matter of Britain_ by Sørina Higgins (review)},
+  url           = {https://www.jstor.org/stable/26809363},
+  author        = {Lobdell, Jared},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {2 (134)},
+  year          = {2019},
+  pages         = {170-186},
+}
+
+@article{mythlore:fisher2019,
+  title         = {_Tolkien, Self and Other: "This Queer Creature"_ by Jane Chance; _Tolkien and Alterity. The New Middle Ages_ by Vaccaro Christopher, Kisor Yvette (review)},
+  url           = {https://www.jstor.org/stable/26809364},
+  author        = {Fisher, Jason},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {2 (134)},
+  year          = {2019},
+  pages         = {187-199},
+}
+
+@article{mythlore:smith2019,
+  title         = {_"The Sweet and the Bitter": Death and Dying in J.~R.~R. Tolkien’s The Lord of the Rings_ by Amy Amendt-Raduege (review)},
+  url           = {https://www.jstor.org/stable/26809367},
+  author        = {Smith, Laura Lee},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {2 (134)},
+  year          = {2019},
+  pages         = {208-211},
+}
+
+@article{mythlore:steele2019,
+  title         = {_The Great Tower of Elfland: The Mythopoeic Worldview of J.~R.~R. Tolkien, C.~S. Lewis, G.~K. Chesterton, and George MacDonald_ by Zachary A. Rhone, Colin Duriez (review)},
+  url           = {https://www.jstor.org/stable/26809369},
+  author        = {Steele, Felicia Jean},
+  journal       = {Mythlore},
+  volume        = {37},
+  number        = {2 (134)},
+  year          = {2019},
+  pages         = {222-226},
+}
+
+-- Mythlore. Vol. 38, No. 1 (135), Fall/Winter 2019, Special Issue: Mythopoeic Children’s Literature
+-- https://www.jstor.org/stable/26809376
+
+@article{mythlore:berube2019,
+  title         = {Extreme Minimalism in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26809383},
+  author        = {Berube, Pierre H.},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {1 (135)},
+  year          = {2019},
+  pages         = {49-51},
+}
+
+@article{mythlore:orth2019,
+  title         = {Mirkwood},
+  url           = {https://www.jstor.org/stable/26809384},
+  author        = {Orth, John V.},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {1 (135)},
+  year          = {2019},
+  pages         = {49-51},
+}
+
+@article{mythlore:swank2019,
+  title         = {The Child’s Voyage and the Immram Tradition in Lewis, Tolkien, and Pullman},
+  url           = {https://www.jstor.org/stable/26809394},
+  author        = {Swank, Kris},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {1 (135)},
+  year          = {2019},
+  pages         = {73-96},
+}
+
+@article{mythlore:marchant2019,
+  title         = {Doubles at Work: The Three Rovers in J.~R.~R. Tolkien’s _Roverandom_},
+  url           = {https://www.jstor.org/stable/26809395},
+  author        = {Marchant, Jennifer},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {1 (135)},
+  year          = {2019},
+  pages         = {97-114},
+}
+
+-- Mythlore. Vol. 38, No. 2 (136), Spring/Summer 2020
+-- https://www.jstor.org/stable/26910120
+
+@article{mythlore:gallant2020,
+  title         = {The _Wyrdwrīteras_ of Elvish History: Northern Courage, Historical Bias, and Literary Artifact as Illustrative Narrative},
+  url           = {https://www.jstor.org/stable/26910124},
+  author        = {Gallant, Richard Z.},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {25-44},
+}
+
+@article{mythlore:chapmanmorales2020,
+  title         = {Fearless Joy: Tom Bombadil’s Function in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/26910126},
+  author        = {Chapman-Morales, Robert B.},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {59-78},
+}
+
+@article{mythlore:jacobs2020,
+  title         = {Tolkien’s Tom Bombadil: An Enigma "(Intentionally)"},
+  url           = {https://www.jstor.org/stable/26910127},
+  author        = {Jacobs, Suzanne},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {79-108},
+}
+
+@article{mythlore:stockton2020,
+  title         = {Inklings and Danteans Alike: C.~S. Lewis, Colin Hardie, Charles Williams, and J.~R.~R. Tolkien’s Participation in the Oxford Dante Society},
+  url           = {https://www.jstor.org/stable/26910132},
+  author        = {Stockton, Jim},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {133-138},
+}
+
+@article{mythlore:dipasquale2020,
+  title         = {_Tolkien and the Classics_ by Robert Arduini, Giampaoplo Canzonieri, Claudio A. Testi (review)},
+  url           = {https://www.jstor.org/stable/26910135},
+  author        = {DiPasquale, Willow},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {189-191},
+}
+
+@article{mythlore:freeman2020,
+  title         = {_Inklings of Truth: Essays to Mark the Anniversaries of C.~S. Lewis and J.~R.~R. Tolkien_ by Paul Shrimpton (review)},
+  url           = {https://www.jstor.org/stable/26910136},
+  author        = {Freeman, Austin},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {191-193},
+}
+
+@article{mythlore:cossio2020,
+  title         = {_Tolkien’s Library: An Annotated Checklist_ by Oronzo Cilli (review)},
+  url           = {https://www.jstor.org/stable/26910138},
+  author        = {Cossio, Andoni},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {195-204},
+}
+
+@article{mythlore:emerson2020,
+  title         = {_Tolkien and Philosophy_ by Roberto Arduini, Claudio A. Testi (review)},
+  url           = {https://www.jstor.org/stable/26910141},
+  author        = {Emerson, David},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {216-217},
+}
+
+@article{mythlore:prothero2020,
+  title         = {_"Something Has Gone Crack": New Perspectives on J.~R.~R. Tolkien in the Great War_ by Janet Brennan Croft, Annika Röttinger (review)},
+  url           = {https://www.jstor.org/stable/26910143},
+  author        = {Prothero, James},
+  journal       = {Mythlore},
+  volume        = {38},
+  number        = {2 (136)},
+  year          = {2020},
+  pages         = {219-221},
+}
+
+-- Mythlore. Vol. 39, No. 1 (137), Fall/Winter 2020
+-- https://www.jstor.org/stable/e26937580
+
+@article{mythlore:inkpen2020,
+  title         = {Tom Bombadil and the Spirit of Objectivity},
+  url           = {https://www.jstor.org/stable/26937588},
+  author        = {Inkpen, Dani},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {1 (137)},
+  year          = {2020},
+  pages         = {117-132},
+}
+
+@article{mythlore:colvin2020,
+  title         = {"Her Enchanted Hair": Rossetti "Lady Lilith," and the Victorian Fascination with Hair as Influences on Tolkien},
+  url           = {https://www.jstor.org/stable/26937589},
+  author        = {Colvin, Kathryn},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {1 (137)},
+  year          = {2020},
+  pages         = {133-148},
+}
+
+@article{mythlore:neubauer2020,
+  title         = {The "Polish Inkling": Professor Przemysław Mroczkowski as J.~R.~R. Tolkien’s Friend and Scholar},
+  url           = {https://www.jstor.org/stable/26937590},
+  author        = {Neubauer, Łukasz},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {1 (137)},
+  year          = {2020},
+  pages         = {149-176},
+}
+
+@article{mythlore:reinhard2020,
+  title         = {Tolkien’s Lost Knights},
+  url           = {https://www.jstor.org/stable/26937591},
+  author        = {Reinhard, Ben},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {1 (137)},
+  year          = {2020},
+  pages         = {177-194},
+}
+
+@article{mythlore:tally2020,
+  title         = {_Utopian and Dystopian Themes in Tolkien’s Legendarium_ by Mark Doyle (review)},
+  url           = {https://www.jstor.org/stable/26937592},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {1 (137)},
+  year          = {2020},
+  pages         = {195-198},
+}
+
+@article{mythlore:fontenot2020,
+  title         = {_Music in Tolkien’s Work and Beyond_ by Julian Eilmann, Friedhelm Schneidewind (review)},
+  url           = {https://www.jstor.org/stable/26937593},
+  author        = {Fontenot, Megan N.},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {1 (137)},
+  year          = {2020},
+  pages         = {198-206},
+}
+
+@article{mythlore:schmoll2020,
+  title         = {_Hobbit Virtues: Rediscovering Virtue Ethics through J.~R.~R. Tolkien’s The Hobbit and The Lord of the Rings_ by Christopher A. Snyder (review)},
+  url           = {https://www.jstor.org/stable/26937594},
+  author        = {Schmoll, Zachary D.},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {1 (137)},
+  year          = {2020},
+  pages         = {206-211},
+}
+
+@article{mythlore:foster2020,
+  title         = {_The Worlds of J.~R.~R. Tolkien: The Places That Inspired Middle-Earth_ by John Garth (review)},
+  url           = {https://www.jstor.org/stable/26937598},
+  author        = {Foster, Mike},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {1 (137)},
+  year          = {2020},
+  pages         = {220-229},
+}
+
+
+-- Mythlore. Vol. 39, No. 2 (138), Spring/Summer 2021, Special Issue: Honoring Ursula K. Le Guin
+-- https://www.jstor.org/stable/e27008152
+
+@article{mythlore:bowers2021,
+  title         = {_Tolkien’s Lost Chaucer_ by John M. Bowers (review)},
+  url           = {https://www.jstor.org/stable/27008165},
+  author        = {Bowers, John M.},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {2 (138)},
+  year          = {2021},
+  pages         = {159-162},
+}
+
+@article{mythlore:glyer2021,
+  title         = {_Journey Back Again: Reasons to Revisit Middle-earth_ by Diana Pavlac Glyer (review)},
+  url           = {https://www.jstor.org/stable/27008172},
+  author        = {Glyer, Diana Pavlac},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {2 (138)},
+  year          = {2021},
+  pages         = {188-191},
+}
+
+@article{mythlore:vaninskaya2021,
+  title         = {_Fantasies of Time and Death: Dunsany, Eddison, Tolkien_ by Anna Vaninskaya (review)},
+  url           = {https://www.jstor.org/stable/27008175},
+  author        = {Vaninskaya, Anna},
+  journal       = {Mythlore},
+  volume        = {39},
+  number        = {2 (138)},
+  year          = {2021},
+  pages         = {199-207},
+}
+
+-- Mythlore. Vol. 40, No. 1 (139), Fall/Winter 2021
+-- https://www.jstor.org/stable/e48509307
+
+@article{mythlore:parrila2021,
+  title         = {All Worthy Things: The Personhood of Nature in J.~R.~R. Tolkien’s Legendarium},
+  url           = {https://www.jstor.org/stable/48659500},
+  author        = {Parrila, Sofia},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {1 (139)},
+  year          = {2021},
+  pages         = {5-20},
+}
+
+@article{mythlore:schurer2021,
+  title         = {The Shape of Water in J.~R.~R. Tolkien’s _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/48659501},
+  author        = {Schürer, Norbert},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {1 (139)},
+  year          = {2021},
+  pages         = {21-41},
+}
+
+@article{mythlore:gustafson2021,
+  title         = {But Where Shall Wisdom Be Found? _The Lord of the Rings_ and the Wisdom Literature of the Hebrew Bible},
+  url           = {https://www.jstor.org/stable/48659507},
+  author        = {Gustafson, Mattie E.},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {1 (139)},
+  year          = {2021},
+  pages         = {145-162},
+}
+
+@article{mythlore:honegger2021,
+  title         = {The Enigmatic Loss of Proto-Hobbitic},
+  url           = {https://www.jstor.org/stable/48659509},
+  author        = {Honegger, Thomas},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {1 (139)},
+  year          = {2021},
+  pages         = {179-192},
+}
+
+@article{mythlore:holmes2021,
+  title         = {How Tolkien Saved His Neck: A Lusinghe Proposition to the Oxford Dante Society},
+  url           = {https://www.jstor.org/stable/48659510},
+  author        = {Holmes, John R.},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {1 (139)},
+  year          = {2021},
+  pages         = {193-207},
+}
+
+@article{mythlore:williams2021,
+  title         = {Keystone or Cornerstone? A Rejoinder to Verlyn Flieger on the Alleged "Conflicting Sides" of Tolkien’s Singular Self},
+  url           = {https://www.jstor.org/stable/48659511},
+  author        = {Williams, Donald T.},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {1 (139)},
+  year          = {2021},
+  pages         = {210-226},
+}
+
+@article{mythlore:swank2021,
+  title         = {_Tolkien’s Modern Reading: Middle-Earth Beyond the Middle Ages_ by Holly Ordway (review)},
+  url           = {https://www.jstor.org/stable/48659515},
+  author        = {Swank, Kris},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {1 (139)},
+  year          = {2021},
+  pages         = {249-256},
+}
+
+@article{mythlore:white2021,
+  title         = {_Tolkien the Pagan?: Reading Middle-Earth through A Spiritual Lens: Proceedings of the Tolkien Society Seminar 2018_ by Anna Milon (review)},
+  url           = {https://www.jstor.org/stable/48659519},
+  author        = {White, Alana},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {1 (139)},
+  year          = {2021},
+  pages         = {264-268},
+}
+
+-- Mythlore. Vol. 40, No. 2 (140), Spring/Summer 2022
+-- https://www.jstor.org/stable/e48509308
+
+@article{mythlore:flieger2022,
+  title         = {A Lost Tale, a Found Influence: Earendel and Tinúviel},
+  url           = {https://www.jstor.org/stable/48659534},
+  author        = {Flieger, Verlyn},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (138)},
+  year          = {2022},
+  pages         = {91-104},
+}
+
+@article{mythlore:dugankrasner2022,
+  title         = {Soup, Bones, and Shakespeare: Literary Authorship and Allusion in Middle-earth},
+  url           = {https://www.jstor.org/stable/48659535},
+  author        = {Dugan, Owen and Krasner, James},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {105-120},
+}
+
+@article{mythlore:ostaltsev2022,
+  title         = {Tolkien and Bakhtin: Symphony of Time in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/48659536},
+  author        = {Ostaltsev, Alex},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {121-138},
+}
+
+@article{mythlore:larsen2022,
+  title         = {Seeing Double: Tolkien and the Indo-European Divine Twins},
+  url           = {https://www.jstor.org/stable/48659537},
+  author        = {Larsen, Kristine},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {139-169},
+}
+
+@article{mythlore:kane2022,
+  title         = {Círdan the Shipwright: Tolkien’s Bodhisattva Who Brings Us to the Other Shore},
+  url           = {https://www.jstor.org/stable/48659538},
+  author        = {Kane, Douglas C.},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {171-184},
+}
+
+@article{mythlore:fitzsimmons2022,
+  title         = {_Ethics and Form in Fantasy Literature: Tolkien, Rowling, and Meyer_ by Lykke Guanio-Uluru (review)},
+  url           = {https://www.jstor.org/stable/48659548},
+  author        = {Fitzsimmons, Phillip},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {258-262},
+}
+
+@article{mythlore:swank2022,
+  title         = {_Tolkien and The Sea: Proceedings of The Tolkien Society Seminar 1996_ by Richard Crawshaw, Shaun Gunner (review)},
+  url           = {https://www.jstor.org/stable/48659549},
+  author        = {Swank, Kris},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {262-266},
+}
+
+@article{mythlore:thibodeaux2022,
+  title         = {_Pagan Saints in Middle-earth_ by Claudio A. Testi (review)},
+  url           = {https://www.jstor.org/stable/48659550},
+  author        = {Thibodeaux, Toni},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {266-269},
+}
+
+@article{mythlore:costabile2022,
+  title         = {_Middle-earth, or There and Back Again. Cormarë Series 44_ by Łukasz Neubauer (review)},
+  url           = {https://www.jstor.org/stable/48659551},
+  author        = {Costabile, Giovanni C.},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {270-272},
+}
+
+@article{mythlore:tally2022a,
+  title         = {_A Sense of Tales Untold: Exploring the Edges of Tolkien’s Literary Canvas_ by Peter Grybauskas (review)},
+  url           = {https://www.jstor.org/stable/48659552},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {272-275},
+}
+
+@article{mythlore:swain2022,
+  title         = {_Tolkien and the Classical World_ by Hamish Williams (review)},
+  url           = {https://www.jstor.org/stable/48659553},
+  author        = {Swain, Larry},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {276-281},
+}
+
+@article{mythlore:houghton2022,
+  title         = {_Musical Scores and the Eternal Present: Theology, Time, and Tolkien_ by Chiara Bertoglio (review)},
+  url           = {https://www.jstor.org/stable/48659554},
+  author        = {Houghton, John Wm.},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {281-284},
+}
+
+@article{mythlore:white2022,
+  title         = {_Leadership in Middle-earth: Theories and Applications for Organizations—Exploring Effective Leadership Practices Through Popular Culture_ by Michael J. Urick (review)},
+  url           = {https://www.jstor.org/stable/48659555},
+  author        = {White, Alana},
+  journal       = {Mythlore},
+  volume        = {40},
+  number        = {2 (140)},
+  year          = {2022},
+  pages         = {284-288},
+}
+
+-- Mythlore. Vol. 41, No. 1 (141), Fall/Winter 2022
+-- https://www.jstor.org/stable/e48511290
+
+@article{mythlore:hall2022,
+  title         = {"The Evil Side of Heroic Life": Monsters and Heroes in Beowulf and _The Hobbit_},
+  url           = {https://www.jstor.org/stable/48692600},
+  author        = {Hall, Catherine},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {1 (141)},
+  year          = {2022},
+  pages         = {187-199},
+}
+
+@article{mythlore:moore2022,
+  title         = {Goddess and Mortal: The Celtic and the French Morgan le Fay in Tolkien’s _Silmarillion_},
+  url           = {https://www.jstor.org/stable/48692601},
+  author        = {Moore, Clare},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {1 (141)},
+  year          = {2022},
+  pages         = {200-218},
+}
+
+@article{mythlore:prezioso2022,
+  title         = {"Well, I’m Back": Samwise Gamgee and the Future of Tolkien’s Literary Pastoral},
+  url           = {https://www.jstor.org/stable/48692602},
+  author        = {Prezioso, MG},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {1 (141)},
+  year          = {2022},
+  pages         = {219-235},
+}
+
+@article{mythlore:bratman2022,
+  title         = {What Sam Said},
+  url           = {https://www.jstor.org/stable/48692604},
+  author        = {Bratman, David},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {1 (141)},
+  year          = {2022},
+  pages         = {250-251},
+}
+
+@article{mythlore:tally2022b,
+  title         = {_Tolkien, Race, and Racism in Middle-earth_ by Robert Stuart (review)},
+  url           = {https://www.jstor.org/stable/48692605},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {1 (141)},
+  year          = {2022},
+  pages         = {253-258},
+}
+
+@article{mythlore:brians2022,
+  title         = {Friendship In _The Lord of the Rings_ by Cristina Casagrande, Eduardo Boheme (review)},
+  url           = {https://www.jstor.org/stable/48692607},
+  author        = {Brians, Mark A.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {1 (141)},
+  year          = {2022},
+  pages         = {261-264},
+}
+
+@article{mythlore:bolding2022,
+  title         = {_Tolkien as a Literary Artist: Exploring Rhetoric, Language and Style in The Lord Of The Rings_ by Thomas Kullmann, Dirk Siepmann (review)},
+  url           = {https://www.jstor.org/stable/48692612},
+  author        = {Bolding, Sharon L.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {1 (141)},
+  year          = {2022},
+  pages         = {277-284},
+}
+
+-- Mythlore. Vol. 41, No. 2 (142), Spring/Summer 2023
+-- https://www.jstor.org/stable/e48513041
+
+@article{mythlore:hood2023,
+  title         = {The _felix culpa_ in Tolkien’s Legendarium: A Catalyst for Character and Reader Transformation},
+  url           = {https://www.jstor.org/stable/48722612},
+  author        = {Hood, Nathan C. J.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {69-88},
+}
+
+@article{mythlore:lockerd2023,
+  title         = {The Stolen Gift: Tolkien and the Problem of Suicide},
+  url           = {https://www.jstor.org/stable/48722613},
+  author        = {Lockerd, Martin},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {89-110},
+}
+
+@article{mythlore:sena2023,
+  title         = {Wizards and Woods: The Environmental Ethics of Tolkien’s Istari},
+  url           = {https://www.jstor.org/stable/48722615},
+  author        = {Sena, Kenton L. and Vogel, Philip J.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {129-144},
+}
+
+@article{mythlore:tadayoni2023,
+  title         = {Gollum from Medieval Tragedy to Liberal Tragedy in J.~R.~R. Tolkien’s _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/48722616},
+  author        = {Tadayoni, Masoud and Hanif, Mohsen},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {145-160},
+}
+
+@article{mythlore:dennis2023,
+  title         = {Delving Too Greedily: Analyzing Prejudice Against Tolkien’s Dwarves as Historical Bias},
+  url           = {https://www.jstor.org/stable/48722617},
+  author        = {Dennis, Mitchell T. and Sena, Kenton L.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {161-184},
+}
+
+@article{mythlore:burriss2023,
+  title         = {Sentience and Sapience in the One Ring: The Reality of Tolkien’s Master Ring},
+  url           = {https://www.jstor.org/stable/48722618},
+  author        = {Burriss, Larry},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {185-198},
+}
+
+@article{mythlore:costabile2023,
+  title         = {The One Ring of King Solomon},
+  url           = {https://www.jstor.org/stable/48722619},
+  author        = {Costabile, Giovanni C.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {198-209},
+}
+
+@article{mythlore:flieger2023,
+  title         = {The Dragon and the Railway Station},
+  url           = {https://www.jstor.org/stable/48722620},
+  author        = {Flieger, Verlyn},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {209-214},
+}
+
+@article{mythlore:alberto2023,
+  title         = {_The Map of Wilderland: Ecocritical Reflections on Tolkien’s Myth of Wilderness_ by Amber Lehning (review)},
+  url           = {https://www.jstor.org/stable/48722628},
+  author        = {Alberto, Maria K.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {247-251},
+}
+
+@article{mythlore:portaencasa2023,
+  title         = {_The Gallant Edith Bratt: J.~R.~R. Tolkien’s Inspiration. Cormarë Series No. 46_ by Nancy Bunting, Seamus Hamill-Keays (review)},
+  url           = {https://www.jstor.org/stable/48722633},
+  author        = {Fernández Portaencasa, María},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {264-266},
+}
+
+@article{mythlore:lenz2023,
+  title         = {_Tolkien, Enchantment, and Loss: Steps on the Developmental Journey_ by John Rosegrant (review)},
+  url           = {https://www.jstor.org/stable/48722636},
+  author        = {Lenz, Timothy K.},
+  journal       = {Mythlore},
+  volume        = {41},
+  number        = {2 (142)},
+  year          = {2023},
+  pages         = {274-280},
+}
+
+-- Mythlore. Vol. 42, No. 1 (143), Fall/Winter 2023
+-- https://www.jstor.org/stable/e48514534
+
+@article{mythlore:leonard2023,
+  title         = {The Posttraumatic Stress Disorder of Frodo Baggins},
+  url           = {https://www.jstor.org/stable/48747476},
+  author        = {Leonard, Bruce},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {5-28},
+}
+
+@article{mythlore:emanuel2023,
+  title         = {It is "about" nothing but itself: Tolkienian Theology Beyond the Domination of the Author},
+  url           = {https://www.jstor.org/stable/48747477},
+  author        = {Emanuel, Tom},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {29-54},
+}
+
+@article{mythlore:bruce2023,
+  title         = {"Or break it": The Cost of SiLmariLs and Sworn Oaths},
+  url           = {https://www.jstor.org/stable/48747478},
+  author        = {Bruce, Alexander M.},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {55-74},
+}
+
+@article{mythlore:danner2023,
+  title         = {Through Fire and Water: The Exodus of the Gondothlim},
+  url           = {https://www.jstor.org/stable/48747479},
+  author        = {Danner, Ethan},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {75-86},
+}
+
+@article{mythlore:henderson2023,
+  title         = {"A Bleak, Barren Land": Women and Fertility in the _Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/48747480},
+  author        = {Henderson, Dylan L.},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {87-106},
+}
+
+@article{mythlore:collins2023,
+  title         = {Otherworldly but not the Otherworld: Tolkien’s adaptation of medieval Faerie and Fairies into a Sub-Creative Elvendom},
+  url           = {https://www.jstor.org/stable/48747481},
+  author        = {Collins, Elliott T.},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {107-120},
+}
+
+@article{mythlore:larsen2023,
+  title         = {The Sun, the Son, and the _Silmarillion_: Christopher Tolkien and the Copernican Revolution of Morgoth’s Ring},
+  url           = {https://www.jstor.org/stable/48747485},
+  author        = {Larsen, Kristine},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {172-179},
+}
+
+@article{mythlore:martsch2023a,
+  title         = {On the Rings of Power: Thoughts Inspired by Larry Burriss’s "Sentience and Sapience in the One Ring"},
+  url           = {https://www.jstor.org/stable/48747486},
+  author        = {Martsch, Nancy},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {179-183},
+}
+
+@article{mythlore:reid2023,
+  title         = {Nine Tolkien Scholars Respond to Charles W. Mills’s "The Wretched of Middle-Earth: An Orkish Manifesto"},
+  url           = {https://www.jstor.org/stable/48747487},
+  author        = {Reid, Robin Anne and Beronio, Bianca L. and Stuart, Robert and Tally Jr., Robert T. and Ue, Tom and Coker, Cait and Agan, Cami and Krausz, Charlotte and Young, Helen},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {183-197},
+}
+
+@article{mythlore:duplessis2023,
+  title         = {_"Uncle Curro": J.~R.~R. Tolkien’s Spanish Connection_ by José Manuel Ferrández Bru (review)},
+  url           = {https://www.jstor.org/stable/48747492},
+  author        = {duPlessis, Nicole M.},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {217-225},
+}
+
+@article{mythlore:ostaltsev2023,
+  title         = {_Tolkien Dogmatics: Theology through Mythology with the Maker of Middle-Earth_ by Austin M. Freeman (review)},
+  url           = {https://www.jstor.org/stable/48747495},
+  author        = {Ostaltsev, Alex},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {230-234},
+}
+
+@article{mythlore:martsch2023b,
+  title         = {_How to Misunderstand Tolkien: The Critics and the Fantasy Master_ by Bruno Bacelli, Silvia Bacelli (review)},
+  url           = {https://www.jstor.org/stable/48747497},
+  author        = {Martsch, Nancy},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {237-242},
+}
+
+@article{mythlore:white2023,
+  title         = {_Adapting Tolkien: Proceedings of the Tolkien Society Seminar 2020_ by Will Sherwood (review)},
+  url           = {https://www.jstor.org/stable/48747499},
+  author        = {White, Alana},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {246-248},
+}
+
+@article{mythlore:martsch2023c,
+  title         = {_Nólë Hyarmenillo: An Anthology of Iberian Scholarship on Tolkien_ by Nuno Simões Rodrigues, Martin Simonson, Angélica Varandas (review)},
+  url           = {https://www.jstor.org/stable/48747501},
+  author        = {Martsch, Nancy},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {253-257},
+}
+
+@article{mythlore:coker2023,
+  title         = {_The Great Tales Never End: Essays in Memory of Christopher Tolkien_ by Richard Ovenden, Catherine McIlwaine (review)},
+  url           = {https://www.jstor.org/stable/48747503},
+  author        = {Coker, Cait},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {1 (143)},
+  year          = {2023},
+  pages         = {260-262},
+}
+
+-- Mythlore. Vol. 42, No. 2 (144), Spring/Summer 2024, Special Issue: Fantasy Goes to Hell
+-- https://www.jstor.org/stable/e48516076
+
+@article{mythlore:harrison2024,
+  title         = {Tolkien, Augustinian Theodicy, and "Lovecraftian" Evil},
+  url           = {https://www.jstor.org/stable/48771987},
+  author        = {Harrison, Perry Neil},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {7-20},
+}
+
+@article{mythlore:costabile2024a,
+  title         = {Orpheus and the Harrowing of Hell in the Tale of Beren and Lúthien},
+  url           = {https://www.jstor.org/stable/48771990},
+  author        = {Costabile, Giovanni C.},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {61-84},
+}
+
+@article{mythlore:thompsonhandell2024,
+  title         = {Some Observations on the Newspaper Reports on Tolkien’s Andrew Lang Lecture in 1939},
+  url           = {https://www.jstor.org/stable/48771998},
+  author        = {Thompson-Handell, Matthew},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {187-190},
+}
+
+@article{mythlore:roux2024,
+  title         = {_The Inklings, the Victorians, and the Moderns: Reconciling tradition in the Modern Age_ by Christopher Butynskyi (review)},
+  url           = {https://www.jstor.org/stable/48772005},
+  author        = {Roux, Hannah Frances},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {206-209},
+}
+
+@article{mythlore:martsch2024,
+  title         = {_J.~R.~R. Tolkien in Central Europe: Context, Directions, and the Legacy._ by Janka Kascakova, David Levente Palatinus (review)},
+  url           = {https://www.jstor.org/stable/48772010},
+  author        = {Martsch, Nancy},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {227-231},
+}
+
+@article{mythlore:vandyke2024,
+  title         = {_Tolkien in the Twenty-First Century: The Meaning of Middle-Earth Today_ by Nick Groom (review)},
+  url           = {https://www.jstor.org/stable/48772011},
+  author        = {Van Dyke, Laura N.},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {232-238}
+}
+
+@article{mythlore:larsen2024,
+  title         = {_Journey Back Again: Reasons to Visit Middle-earth_ by Diana Pavlac Glyer (review)},
+  url           = {https://www.jstor.org/stable/48772015},
+  author        = {Larsen, Kristine},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {247-255},
+}
+
+@article{mythlore:beronio2024,
+  title         = {_J.~R.~R. Tolkien’s The Hobbit: Realizing History Through Fantasy_ by Robert T. Tally Jr. (review)},
+  url           = {https://www.jstor.org/stable/48772016},
+  author        = {Beronio, Bianca},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {255-259},
+}
+
+@article{mythlore:loftin2024,
+  title         = {_The Road to Fair Elfland: Tolkien on Fairy-stories: An Extended Commentary_ by Giovanni Carmine Costabile (review)},
+  url           = {https://www.jstor.org/stable/48772019},
+  author        = {Loftin, Landon},
+  journal       = {Mythlore},
+  volume        = {42},
+  number        = {2 (144)},
+  year          = {2024},
+  pages         = {264-265},
+}
+
+-- Mythlore. Vol. 43, No. 1 (145), Fall/Winter 2024
+-- https://www.jstor.org/stable/e48517389
+
+@article{mythlore:johnson2024,
+  title         = {The Catholic Imaginations of J.~R.~R. Tolkien and Oscar Wilde},
+  url           = {https://www.jstor.org/stable/48792475},
+  author        = {Johnson, Frazier Alexander},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {19-40},
+}
+
+@article{mythlore:smol2024,
+  title         = {Tolkien The Playwright: Manuscript Revisions and Faërian Dramas in "The Homecoming of Beorhtnoth"},
+  url           = {https://www.jstor.org/stable/48792479},
+  author        = {Smol, Anna},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {109-126},
+}
+
+@article{mythlore:moore2024,
+  title         = {Elmar, Aerin, and Aredhel: Female Enslavement in Tolkien’s Legendarium},
+  url           = {https://www.jstor.org/stable/48792481},
+  author        = {Moore, Clare},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {143-166},
+}
+
+@article{mythlore:retakh2024,
+  title         = {The Inconsistencies of Galadriel: The Influence of Earlier Legendarium in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/48792483},
+  author        = {Retakh, Alexander},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {185-210},
+}
+
+@article{mythlore:moorehagan2024,
+  title         = {A Bleak, Barren Take: A Response to "Woman and Fertility in _The Lord of the Rings_"},
+  url           = {https://www.jstor.org/stable/48792485},
+  author        = {Moore, Clare and Hagan, Leah},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {227-234},
+}
+
+@article{mythlore:flieger2024,
+  title         = {Tolkien’s Lúthien: From Life to Art to Life as Art},
+  url           = {https://www.jstor.org/stable/48792486},
+  author        = {Flieger, Verlyn},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {234-240},
+}
+
+@article{mythlore:tally2024,
+  title         = {_J.~R.~R. Tolkien’s Utopianism and the Classics_ by Hamish Williams (review)},
+  url           = {https://www.jstor.org/stable/48792489},
+  author        = {Tally, Robert T.},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {265-268},
+}
+
+@article{mythlore:portaencasa2024,
+  title         = {_The Literary Role of History in the Fiction of J.~R.~R. Tolkien_ by Nicholas Birns (review)},
+  url           = {https://www.jstor.org/stable/48792492},
+  author        = {Fernández Portaencasa, María},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {275-281},
+}
+
+@article{mythlore:costabile2024b,
+  title         = {_Pity, Power, and Tolkien’s Ring: To Rule the Fate of Many_ by Thomas P. Hillman (review)},
+  url           = {https://www.jstor.org/stable/48792496},
+  author        = {Costabile, Giovanni C.},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {288-292},
+}
+
+@article{mythlore:schurer2024,
+  title         = {_Representing Middle-Earth: Tolkien, Form, and Ideology_ by Robert T. Tally Jr. (review)},
+  url           = {https://www.jstor.org/stable/48792498},
+  author        = {Schürer, Norbert},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {296-300},
+}
+
+@article{mythlore:griffinordway2024,
+  title         = {_Tolkien’s Faith: A Spiritual Biography_ by Holly Ordway, William Griffin (review)},
+  url           = {https://www.jstor.org/stable/48792499},
+  author        = {Griffin, William and Ordway, Holly},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {301-306},
+}
+
+@article{mythlore:coker2024,
+  title         = {_Reading Tolkien in Chinese: Religion, Fantasy, and Translation_ by Eric Reinders (review)},
+  url           = {https://www.jstor.org/stable/48792503},
+  author        = {Coker, Cait},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {317-321},
+}
+
+@article{mythlore:forchhammer2024,
+  title         = {_Binding Them All: Interdisciplinary Perspectives on J.~R.~R. Tolkien and His Works_ by Monika Kirner-Ludwig, Stephan Köser, Sebastian Streitberger (review)},
+  url           = {https://www.jstor.org/stable/48792504},
+  author        = {Forchhammer, Troels},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {1 (145)},
+  year          = {2024},
+  pages         = {321-323},
+}
+
+-- Mythlore. Vol. 43, No. 2 (146), Spring/Summer 2025
+-- https://www.jstor.org/stable/e48519323
+
+@article{mythlore:thompsonhandell2025a,
+  title         = {No Ragnarök, No Armageddon: Pagan and Christian interpretations of _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/48820326},
+  author        = {Thompson-Handell, Matthew},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {5-26},
+}
+
+@article{mythlore:emanuel2025,
+  title         = {An Aspirational Cultus? Tolkien Fandom at the Borders of Belief},
+  url           = {https://www.jstor.org/stable/48820327},
+  author        = {Emanuel, Tom},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {27-50},
+}
+
+@article{mythlore:reinders2025,
+  title         = {Divinity and the Void in Chinese and Thai Translations of the _Ainulindalë_},
+  url           = {https://www.jstor.org/stable/48820328},
+  author        = {Reinders, Eric},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {51-66},
+}
+
+@article{mythlore:mckenna2025,
+  title         = {The Liberty to Bind Oneself: Chesterton and The Oath of Fëanor},
+  url           = {https://www.jstor.org/stable/48820330},
+  author        = {McKenna, Matthew},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {83-94},
+}
+
+@article{mythlore:davis2025,
+  title         = {The Bright Sword and its Sharpness: Swords, Symbolism, and Medievalism in _The Lord of the Rings_},
+  url           = {https://www.jstor.org/stable/48820336},
+  author        = {Davis, Gavin S.},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {183-200},
+}
+
+@article{mythlore:neubauer2025,
+  title         = {Interview with Professor John McKinnell Concerning Tolkien’s Lectures on Beowulf},
+  url           = {https://www.jstor.org/stable/48820338},
+  author        = {Neubauer, Łukasz and McKinnell, John},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {215-222},
+}
+
+@article{mythlore:thompsonhandell2025b,
+  title         = {"Better to Reign in Hell": Ambivalence and Orcs in the _Lay of the Children of Húrin_},
+  url           = {https://www.jstor.org/stable/48820339},
+  author        = {Thompson-Handell, Matthew},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {222-226},
+}
+
+@article{mythlore:alexander2025,
+  title         = {Weaving Wikipedia’s Middle-earth Web},
+  url           = {https://www.jstor.org/stable/48820341},
+  author        = {Alexander, Ian F.},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {239-243},
+}
+
+@article{mythlore:reid2025,
+  title         = {"Perilous and Fair" in "A Bleak, Barren Land": A Feminist Responds to Dylan Lee Henderson’s Essay},
+  url           = {https://www.jstor.org/stable/48820343},
+  author        = {Reid, Robin A.},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {253-269},
+}
+
+@article{mythlore:vandyke2025,
+  title         = {_J.~R.~R. Tolkien: A Very Short Introduction_ by Matthew Townend (review)},
+  url           = {https://www.jstor.org/stable/48820344},
+  author        = {Van Dyke, Laura N.},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {270-275},
+}
+ 
+@article{mythlore:fitzsimmons2025,
+  title         = {_Tolkien’s Cosmology: Divine Beings and Middle-earth_ by Sam McBride (review)},
+  url           = {https://www.jstor.org/stable/48820345},
+  author        = {Fitzsimmons, Phillip},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {275-277},
+}
+
+@article{mythlore:gruenler2025,
+  title         = {_Mimetic Theory & Middle-Earth: Untangling Desire in Tolkien’s Legendarium_ by Matthew J. Distefano (review)},
+  url           = {https://www.jstor.org/stable/48820347},
+  author        = {Gruenler, Curtis},
+  journal       = {Mythlore},
+  volume        = {43},
+  number        = {2 (146)},
+  year          = {2025},
+  pages         = {280-283},
+}
+
+-- EOF

--- a/bibliographies/tolkien/en/mythlore.bib
+++ b/bibliographies/tolkien/en/mythlore.bib
@@ -1,3 +1,16 @@
+% -- Bibliography for Tolkien-related articles in the Mythlore Journal
+% License: CC BY-SA 4.0
+% Copyright: Le Dragon de Brume
+% Compiled by: Didier Willis (2025)
+%
+% By design:
+% This BibTeX file is in UTF-8 encoding, without any TeX-specific code.
+% Special:
+%    italicExtension (_text_ for emphasized text)
+%
+% Note:
+% Articles of a general nature or on other authors, not specifically Tolkien-related, are not included.
+
 -- Mythlore. Vol. 1, No. 1, January 1969
 -- https://www.jstor.org/stable/i26807204
 
@@ -7232,7 +7245,7 @@ T@article{mythlore:bratman2000,
   year          = {2025},
   pages         = {270-275},
 }
- 
+
 @article{mythlore:fitzsimmons2025,
   title         = {_Tolkien’s Cosmology: Divine Beings and Middle-earth_ by Sam McBride (review)},
   url           = {https://www.jstor.org/stable/48820345},

--- a/bibliographies/tolkien/en/tkstudies.bib
+++ b/bibliographies/tolkien/en/tkstudies.bib
@@ -3124,7 +3124,7 @@
 
 @article{tks:duplessis2018,
   title   = {Changed, Changed Utterly: The Implications of Tolkien’s Rejected Epilogue to _The Lord of the Rings_},
-  author  = {duPlessis, Nicole},
+  author  = {duPlessis, Nicole M.},
   journal = {Tolkien Studies},
   number  = {15},
   year    = {2018},

--- a/bibliographies/tolkien/en/ts.bib
+++ b/bibliographies/tolkien/en/ts.bib
@@ -32,7 +32,7 @@
 
 @book{ts:1995,
   title       = {Proceedings of the J.~R.~R. Tolkien Centenary Conference 1992},
-  editor      = {Reynolds, Patricia and GoodKnight, Glen},
+  editor      = {Reynolds, Patricia and GoodKnight, Glen H.},
   year        = {1995},
   publisher   = {The Tolkien Society},
 }

--- a/bibliographies/tolkien/fr/tolkiendil-web.bib
+++ b/bibliographies/tolkien/fr/tolkiendil-web.bib
@@ -573,6 +573,8 @@
   publisher  = {Tolkiendil},
   year       = {2018},
   url        = {http://www.tolkiendil.com/essais/religion/disbelieve},
+  related     = {mythlore:bossert2006},
+  relatedtype = {translationof},
 }
 
 [« Il valore educativo dell’Esperanto, parola di Tolkien in “The British Esperantist” del 1933, article en ligne, 2014]

--- a/bibliographies/tolkien/fr/tolkiendil-web.bib
+++ b/bibliographies/tolkien/fr/tolkiendil-web.bib
@@ -358,7 +358,9 @@
   author    = {Sainton, Jérôme},
   title     = {Du "Marring" au "Marrissement"},
   publisher = {Tolkiendil},
-  year      = {2015 [2011, 2004]},
+  origdate  = {2011},
+  year      = {2015},
+  edition   = {3},
   url       = {http://www.tolkiendil.com/essais/religion/du_marring_au_marrissement},
 }
 
@@ -428,7 +430,9 @@
   author    = {Turlin, Jean-Rodolphe},
   title     = {De la nature de Gothmog, lieutenant de Morgul},
   publisher = {Tolkiendil},
-  year      = {2013 [2008]},
+  origdate  = {2008},
+  year      = {2013},
+  edition   = {2},
   url       = {http://www.tolkiendil.com/essais/personnages/gothmog},
 }
 @misc{tolkiendil:turlin2010,
@@ -442,7 +446,9 @@
   author    = {Turlin, Jean-Rodolphe},
   title     = {Les prénoms des Hobbits},
   publisher = {Tolkiendil},
-  year      = {2013 [2003]},
+  origdate  = {2003},
+  year      = {2013},
+  edition   = {2},
   url       = {http://www.tolkiendil.com/essais/peuples/prenoms_hobbits},
 }
 
@@ -458,7 +464,7 @@
   author    = {Willis, Didier},
   title     = {Les archétypes du conte merveilleux chez Tolkien},
   publisher = {Tolkiendil},
-  year      = {1999-2000},
+  year      = {2000},
   url       = {http://www.tolkiendil.com/essais/influences/archetypes_propp},
 }
 @misc{tolkiendil:willis1999b,
@@ -472,7 +478,7 @@
   author    = {Willis, Didier},
   title     = {Une phrase elfique dans _J.~R.~R. Tolkien, Artist & Illustrator_},
   publisher = {Tolkiendil},
-  year      = {1999-2000},
+  year      = {2000},
   url       = {https://www.tolkiendil.com/langues/langues_elfiques/noldorin/phrase_noldorin_tai},
 }
 @misc{tolkiendil:willis2001a,
@@ -486,21 +492,27 @@
   author    = {Willis, Didier},
   title     = {Míriel, ou la confrontation de la lune et du soleil},
   publisher = {Tolkiendil},
-  year      = {2013 [2007, 2001]},
+  origdate  = {2001},
+  year      = {2013},
+  edition   = {3},
   url       = {http://www.tolkiendil.com/essais/personnages/miriel_lune_soleil},
 }
 @misc{tolkiendil:willis2002,
   author    = {Willis, Didier},
   title     = {Du Bien, du Mal et de leur origine},
   publisher = {Tolkiendil},
-  year      = {2001-2002},
+  origdate  = {2001},
+  year      = {2002},
+  edition   = {2},
   url       = {http://www.tolkiendil.com/essais/religion/bien_et_mal},
 }
 @misc{tolkiendil:willis2003,
   author    = {Willis, Didier},
   title     = {Entre Hostie et Manne: _Lembas ar Coimas_},
   publisher = {Tolkiendil},
-  year      = {2002-2003},
+  origdate  = {2002},
+  year      = {2003},
+  edition   = {2},
   url       = {http://www.tolkiendil.com/essais/religion/hostie_et_manne},
 }
 @misc{tolkiendil:willis2008,
@@ -573,8 +585,7 @@
   publisher  = {Tolkiendil},
   year       = {2018},
   url        = {http://www.tolkiendil.com/essais/religion/disbelieve},
-  related     = {mythlore:bossert2006},
-  relatedtype = {translationof},
+  xref       = {mythlore:bossert2006},
 }
 
 [« Il valore educativo dell’Esperanto, parola di Tolkien in “The British Esperantist” del 1933, article en ligne, 2014]
@@ -703,7 +714,7 @@ François, Anne-Isabelle, « “A Club of the Other Sort”. Coteries, cercles, 
   translator = {Stocker, Vivien},
   title      = {Tolkien et le magnétophone à bandes},
   publisher  = {Tolkiendil},
-  year       = {[2013] 2016},
+  year       = {2016},
   url        = {http://www.tolkiendil.com/tolkien/etudes/tolkien_magnetophone},
 }
 
@@ -823,6 +834,7 @@ http://www.tolkiendil.com/essais/divers/geographie
   translator = {Dubost, Odilon},
   title      = {Religion en Terre du Milieu: comment ça marche, et qu’est-ce que ça fait ?},
   publisher  = {Tolkiendil},
+  year       = {2005},
   url        = {http://www.tolkiendil.com/essais/divers/religion},
   xref       = {otherhands:seeman1993},
 }


### PR DESCRIPTION
Objectives:
 - Indexation of the _Mythlore_ journal (Tolkien-related entries only)
 - Some fixes in other resources seen in passing (for consolidation etc.)

N.B. Editorial committee, see Dragon de Brume HS Bibliography (3d edition) shared charter document = "Stage 2.1"